### PR TITLE
docs: edit quickstart with correct args to FT.CREATE

### DIFF
--- a/docs/Quick_Start.md
+++ b/docs/Quick_Start.md
@@ -15,7 +15,7 @@ make all
 ## Creating an index with fields and weights:
 
 ```
-127.0.0.1:6379> FT.CREATE myIdx title TEXT 5.0 body TEXT 1.0 url 1.0
+127.0.0.1:6379> FT.CREATE myIdx title 5.0 body 1.0 url 1.0
 OK 
 
 ``` 


### PR DESCRIPTION
Should be
FT.CREATE myIdx title 5.0 body 1.0 url 1.0

Was
CREATE myIdx title TEXT 5.0 body TEXT 1.0 url 1.0

which lead to this error:
(error) Could not parse field specs