### PR TITLE
docs: fix link to supported languages, link to redis_buffer.c

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -21,7 +21,7 @@ See [https://github.com/RedisLabs/RedisModulesSDK/blob/master/FUNCTIONS.md#redis
 
 We use this API in the module mainly to encode inverted indexes, and for other auxiliary data structures besides that. 
 
-A generic "Buffer" implementation using DMA strings can be found in [redis_buffer.c](src/redis_buffer.c). It automatically resizes
+A generic "Buffer" implementation using DMA strings can be found in [redis_buffer.c](../src/redis_buffer.c). It automatically resizes
 the redis string it uses as raw memory, when the capacity needs to grow.
  
 ## Inverted index encoding

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ traditional redis search approaches.
 * Field weights.
 * Auto-complete suggestions (with fuzzy prefix suggestions)
 * Exact Phrase Search of up to 8 words.
-* Stemming based query expansion in [many languages](#stemming-support) (using [Snowball](http://snowballstem.org/)).
+* Stemming based query expansion in [many languages](Stemming.md#supported-languages) (using [Snowball](http://snowballstem.org/)).
 * Limiting searches to specific document fields (up to 8 fields supported).
 * Numeric filters and ranges.
 * Supports any utf-8 encoded text.


### PR DESCRIPTION
Link in docs/index.md to supported languages pointed to the current document instead of to **Stemming.md**, which is the location for the information about supported languages.

Also fix link to **redis_buffer.c** in **DESIGN.md**