### PR TITLE
Patch typo in Python trie unicode test

### DIFF
--- a/src/tests/test_trie.c
+++ b/src/tests/test_trie.c
@@ -133,7 +133,7 @@ int testTrie() {
 
 int testUnicode() {
 
-  char *str = "\xc4\x8caji\xc4\x87";
+  char *str = "\xc4\x8c\xc4\x87";
 
   rune *rn = __strToRunes("", NULL);
   TrieNode *root = __newTrieNode(rn, 0, 0, 0, 1, 0);


### PR DESCRIPTION
Was preventing tests from passing with error:

```
test_trie.c:136:20: error: hex escape sequence out of range
  char *str = "\xc4\x8caji\xc4\x87";
```