### PR TITLE
Normalize and fold Unicode text in auto-complete

### DIFF
--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -56,4 +56,8 @@ test: test_index test_stemmer test_trie
 
 all: build test
 
+clean:
+	-rm -f *.o
+.PHONY: clean
+
 rebuild: clean all

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -60,11 +60,11 @@ int testDistance() {
   IndexResult_PutRecord(&res, &(IndexRecord){.docId = 1, .offsets = *vw2->bw.buf});
 
   int delta = IndexResult_MinOffsetDelta(&res);
-  ASSERT_EQUAL_INT(4, delta);
+  ASSERT_EQUAL(4, delta);
 
   IndexResult_PutRecord(&res, &(IndexRecord){.docId = 1, .offsets = *vw3->bw.buf});
   delta = IndexResult_MinOffsetDelta(&res);
-  ASSERT_EQUAL_INT(53, delta);
+  ASSERT_EQUAL(53, delta);
 
   VVW_Free(vw);
   VVW_Free(vw2);
@@ -500,14 +500,14 @@ int testIndexFlags() {
   ASSERT(w->flags == flags);
   size_t sz = IW_WriteEntry(w, &h);
   // printf("written %d bytes\n", sz);
-  ASSERT_EQUAL_INT(18, sz);
+  ASSERT_EQUAL(18, sz);
   IW_Free(w);
 
   flags &= ~Index_StoreTermOffsets;
   w = NewIndexWriter(1, flags);
   ASSERT(!(w->flags & Index_StoreTermOffsets));
   size_t sz2 = IW_WriteEntry(w, &h);
-  ASSERT_EQUAL_INT(sz2, sz - VV_Size(h.vw->bw.buf) - 1);
+  ASSERT_EQUAL(sz2, sz - VV_Size(h.vw->bw.buf) - 1);
   IW_Free(w);
 
   flags &= ~Index_StoreFieldFlags;
@@ -515,7 +515,7 @@ int testIndexFlags() {
   ASSERT(!(w->flags & Index_StoreTermOffsets));
   ASSERT(!(w->flags & Index_StoreFieldFlags));
   sz = IW_WriteEntry(w, &h);
-  ASSERT_EQUAL_INT(6, sz);
+  ASSERT_EQUAL(6, sz);
   IW_Free(w);
 
   VVW_Free(h.vw);
@@ -532,14 +532,14 @@ int testDocTable() {
   for (int i = 0; i < N; i++) {
     sprintf(buf, "doc_%d", i);
     t_docId nd = DocTable_Put(&dt, buf, (double)i, Document_DefaultFlags);
-    ASSERT_EQUAL_INT(did + 1, nd);
+    ASSERT_EQUAL(did + 1, nd);
     did = nd;
   }
 
-  ASSERT_EQUAL_INT(N + 1, dt.size);
-  ASSERT_EQUAL_INT(N, dt.maxDocId);
+  ASSERT_EQUAL(N + 1, dt.size);
+  ASSERT_EQUAL(N, dt.maxDocId);
   ASSERT(dt.cap > dt.size);
-  ASSERT_EQUAL_INT(1890, (int)dt.memsize);
+  ASSERT_EQUAL(1890, (int)dt.memsize);
 
   for (int i = 0; i < N; i++) {
     sprintf(buf, "doc_%d", i);
@@ -548,21 +548,21 @@ int testDocTable() {
     ASSERT_STRING_EQ(k, buf);
 
     float score = DocTable_GetScore(&dt, i + 1);
-    ASSERT_EQUAL_INT((int)score, i);
+    ASSERT_EQUAL((int)score, i);
 
     DocumentMetadata *dmd = DocTable_Get(&dt, i + 1);
     ASSERT(dmd != NULL);
     ASSERT_STRING_EQ(dmd->key, buf);
-    ASSERT_EQUAL_INT((int)dmd->score, i);
-    ASSERT_EQUAL_INT((int)dmd->flags, (int)Document_DefaultFlags);
+    ASSERT_EQUAL((int)dmd->score, i);
+    ASSERT_EQUAL((int)dmd->flags, (int)Document_DefaultFlags);
 
     t_docId xid = DocIdMap_Get(&dt.dim, buf);
 
-    ASSERT_EQUAL_INT((int)xid, i + 1);
+    ASSERT_EQUAL((int)xid, i + 1);
 
     int rc = DocTable_Delete(&dt, dmd->key);
-    ASSERT_EQUAL_INT(1, rc);
-    ASSERT_EQUAL_INT((int)dmd->flags, (int)Document_Deleted);
+    ASSERT_EQUAL(1, rc);
+    ASSERT_EQUAL((int)dmd->flags, (int)Document_Deleted);
   }
 
   ASSERT(0 == DocIdMap_Get(&dt.dim, "foo bar"));

--- a/src/tests/test_query.c
+++ b/src/tests/test_query.c
@@ -121,10 +121,10 @@ int testQueryExpander() {
 
   if (err) FAIL("Error parsing query: %s", err);
 
-  ASSERT_EQUAL_INT(q->numTokens, 2)
+  ASSERT_EQUAL(q->numTokens, 2)
   Query_Expand(q);
   __queryNode_Print(n, 0);
-  ASSERT_EQUAL_INT(q->numTokens, 4)
+  ASSERT_EQUAL(q->numTokens, 4)
 
   ASSERT(n->pn.children[0]->type == QN_UNION);
   ASSERT_STRING_EQ("hello", n->pn.children[0]->un.children[0]->tn.str);

--- a/src/tests/test_trie.c
+++ b/src/tests/test_trie.c
@@ -160,8 +160,8 @@ int testDFAFilter() {
 
   printf("loaded %d entries\n", i);
 
-  char *terms[] = {"dostoevsky", "dostoevski", "cbs",     "cbxs", "gangsta",
-                   "gengsta",    "jezebel",    "hezebel",  "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d", "\xd7\xa9\xd7\x97\xd7\x95\xd7\x9d", NULL};
+  char *terms[] = {"DostOEvsky", "dostoevski", "cbs",     "cbxs", "gangsta",
+                   "geNGsta",    "jezebel",    "hezebel",  "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d", "\xd7\xa9\xd7\x97\xd7\x95\xd7\x9d", NULL};
   struct timespec start_time, end_time;
   clock_gettime(CLOCK_REALTIME, &start_time);
   unsigned long long totalns = 0;

--- a/src/tests/test_trie.c
+++ b/src/tests/test_trie.c
@@ -167,7 +167,7 @@ int testDFAFilter() {
   unsigned long long totalns = 0;
 
   for (i = 0; terms[i] != NULL; i++) {
-    runes = __strToRunes(terms[i], &rlen);
+    runes = __strToFoldedRunes(terms[i], &rlen);
     DFAFilter fc = NewDFAFilter(runes, rlen, 2, 0);
 
     TrieIterator *it = TrieNode_Iterate(root, FilterFunc, StackPop, &fc);

--- a/src/tests/test_trie.c
+++ b/src/tests/test_trie.c
@@ -55,9 +55,9 @@ int testRuneUtil() {
   rune expectedRunes[3] = {121, 89, 3};
   size_t len;
   rune *runes = strToRunes(str, &len);
-  ASSERT_EQUAL_INT(len, 2);
-  ASSERT_EQUAL_INT(runes[0], expectedRunes[0]);
-  ASSERT_EQUAL_INT(runes[1], expectedRunes[1]);
+  ASSERT_EQUAL(len, 2);
+  ASSERT_EQUAL(runes[0], expectedRunes[0]);
+  ASSERT_EQUAL(runes[1], expectedRunes[1]);
   free(runes);
   // convert from runes back to string
   size_t backToStrLen;
@@ -70,37 +70,37 @@ int testRuneUtil() {
   rune expectedUnicodeRunes[5] = {216, 8719, 960, 229, 197};
   char *expectedUnicodeStr = "Ø∏πåÅ";
   rune *unicodeRunes = strToRunes(expectedUnicodeStr, &unicodeLen);
-  ASSERT_EQUAL_INT(unicodeLen, 5);
+  ASSERT_EQUAL(unicodeLen, 5);
   for (int i = 0; i < 5; i++) {
-    ASSERT_EQUAL_INT(unicodeRunes[i], expectedUnicodeRunes[i]);
+    ASSERT_EQUAL(unicodeRunes[i], expectedUnicodeRunes[i]);
   }
   free(unicodeRunes);
   // convert from runes back to string
   size_t backUnicodeStrUtfLen;
   char *backUnicodeStr = runesToStr(expectedUnicodeRunes, 2, &backUnicodeStrUtfLen);
   for (int i = 0; i < 5; i++) {
-    ASSERT_EQUAL_INT(backUnicodeStr[i], expectedUnicodeStr[i]);
+    ASSERT_EQUAL(backUnicodeStr[i], expectedUnicodeStr[i]);
   }
   free(backUnicodeStr);
 
   size_t foldedLen;
   rune *foldedRunes = strToFoldedRunes("yY", &foldedLen);
-  ASSERT_EQUAL_INT(foldedLen, 2);
-  ASSERT_EQUAL_INT(foldedRunes[0], 121);
-  ASSERT_EQUAL_INT(foldedRunes[1], 121);
+  ASSERT_EQUAL(foldedLen, 2);
+  ASSERT_EQUAL(foldedRunes[0], 121);
+  ASSERT_EQUAL(foldedRunes[1], 121);
   free(foldedRunes);
 
   // TESTING ∏ and Å because ∏ doesn't have a lowercase form, but Å does
   size_t foldedUnicodeLen;
   rune *foldedUnicodeRunes = strToFoldedRunes("Ø∏πåÅ", &foldedUnicodeLen);
-  ASSERT_EQUAL_INT(runeFold(foldedUnicodeRunes[1]), foldedUnicodeRunes[1]); 
-  ASSERT_EQUAL_INT(foldedUnicodeLen, 5);
-  ASSERT_EQUAL_INT(foldedUnicodeRunes[0], 248);
-  ASSERT_EQUAL_INT(foldedUnicodeRunes[1], 8719);
-  ASSERT_EQUAL_INT(foldedUnicodeRunes[2], 960);
-  ASSERT_EQUAL_INT(foldedUnicodeRunes[3], 229);
-  ASSERT_EQUAL_INT(foldedUnicodeRunes[4], 229);
-  ASSERT_EQUAL_INT(runeFold(foldedUnicodeRunes[4]), foldedUnicodeRunes[3]);
+  ASSERT_EQUAL(runeFold(foldedUnicodeRunes[1]), foldedUnicodeRunes[1]); 
+  ASSERT_EQUAL(foldedUnicodeLen, 5);
+  ASSERT_EQUAL(foldedUnicodeRunes[0], 248);
+  ASSERT_EQUAL(foldedUnicodeRunes[1], 8719);
+  ASSERT_EQUAL(foldedUnicodeRunes[2], 960);
+  ASSERT_EQUAL(foldedUnicodeRunes[3], 229);
+  ASSERT_EQUAL(foldedUnicodeRunes[4], 229);
+  ASSERT_EQUAL(runeFold(foldedUnicodeRunes[4]), foldedUnicodeRunes[3]);
   free(foldedUnicodeRunes);
 
   return 0;
@@ -113,12 +113,12 @@ int testTrie() {
   free(rootRunes);
 
   int rc = __trie_add(&root, "hello", 1, ADD_REPLACE);
-  ASSERT_EQUAL_INT(1, rc);
+  ASSERT_EQUAL(1, rc);
   rc = __trie_add(&root, "hello", 1, ADD_REPLACE);
-  ASSERT_EQUAL_INT(0,
+  ASSERT_EQUAL(0,
                    rc); // the second insert of the same term should result in 0
   rc = __trie_add(&root, "help", 2, ADD_REPLACE);
-  ASSERT_EQUAL_INT(1, rc);
+  ASSERT_EQUAL(1, rc);
 
   __trie_add(&root, "helter skelter", 3, ADD_REPLACE);
   size_t rlen;
@@ -165,9 +165,9 @@ int testUnicode() {
   ASSERT(root != NULL)
 
   int rc = __trie_add(&root, str, 1, ADD_REPLACE);
-  ASSERT_EQUAL_INT(1, rc);
+  ASSERT_EQUAL(1, rc);
   rc = __trie_add(&root, str, 1, ADD_REPLACE);
-  ASSERT_EQUAL_INT(0, rc);
+  ASSERT_EQUAL(0, rc);
   size_t rlen;
   rune *runes = strToRunes(str, &rlen);
   float sc = TrieNode_Find(root, runes, rlen);

--- a/src/tests/test_trie.c
+++ b/src/tests/test_trie.c
@@ -42,7 +42,7 @@ FilterCode stepFilter(unsigned char b, void *ctx, int *matched,
 
 int __trie_add(TrieNode **n, char *str, float sc, TrieAddOp op) {
   size_t rlen;
-  rune *runes = __strToRunes(str, &rlen); 
+  rune *runes = strToRunes(str, &rlen); 
   
    int rc = TrieNode_Add(n, runes, rlen, sc, op);
    free(runes);
@@ -51,7 +51,7 @@ int __trie_add(TrieNode **n, char *str, float sc, TrieAddOp op) {
 
 
 int testTrie() {
-  TrieNode *root = __newTrieNode(__strToRunes("", NULL), 0, 0, 0, 1, 0);
+  TrieNode *root = __newTrieNode(strToRunes("", NULL), 0, 0, 0, 1, 0);
   ASSERT(root != NULL)
 
   int rc = __trie_add(&root, "hello", 1, ADD_REPLACE);
@@ -64,7 +64,7 @@ int testTrie() {
 
   __trie_add(&root, "helter skelter", 3, ADD_REPLACE);
   size_t rlen;
-  rune *runes = __strToRunes("helter skelter", &rlen);
+  rune *runes = strToRunes("helter skelter", &rlen);
   float sc = TrieNode_Find(root, runes, rlen);
   ASSERT(sc == 3);
 
@@ -101,7 +101,7 @@ int testUnicode() {
 
   char *str = "\xc4\x8c\xc4\x87";
 
-  rune *rn = __strToRunes("", NULL);
+  rune *rn = strToRunes("", NULL);
   TrieNode *root = __newTrieNode(rn, 0, 0, 0, 1, 0);
   free(rn);
   ASSERT(root != NULL)
@@ -111,7 +111,7 @@ int testUnicode() {
   rc = __trie_add(&root, str, 1, ADD_REPLACE);
   ASSERT_EQUAL_INT(0, rc);
   size_t rlen;
-  rune *runes = __strToRunes(str, &rlen);
+  rune *runes = strToRunes(str, &rlen);
   float sc = TrieNode_Find(root, runes, rlen);
   free(runes);
   ASSERT(sc == 1);
@@ -128,7 +128,7 @@ int testDFAFilter() {
   size_t len = 0;
   ssize_t read;
   size_t rlen;
-  rune *runes = __strToRunes("root", &rlen);
+  rune *runes = strToRunes("root", &rlen);
   TrieNode *root = __newTrieNode(runes, 0, rlen, 0, 0, 0);
   ASSERT(root != NULL)
   free(runes);
@@ -145,7 +145,7 @@ int testDFAFilter() {
       *sep-- = 0;
     }
 
-    runes = __strToRunes(line, &rlen);
+    runes = strToRunes(line, &rlen);
     int rc = TrieNode_Add(&root, runes, rlen, (float)score, ADD_REPLACE);
     ASSERT(rc == 1);
     free(runes);
@@ -167,7 +167,7 @@ int testDFAFilter() {
   unsigned long long totalns = 0;
 
   for (i = 0; terms[i] != NULL; i++) {
-    runes = __strToFoldedRunes(terms[i], &rlen);
+    runes = strToFoldedRunes(terms[i], &rlen);
     DFAFilter fc = NewDFAFilter(runes, rlen, 2, 0);
 
     TrieIterator *it = TrieNode_Iterate(root, FilterFunc, StackPop, &fc);
@@ -184,7 +184,7 @@ int testDFAFilter() {
       ASSERT(len > 0);
 
       // size_t ulen;
-      // char *str = __runesToStr(s, len, &ulen);
+      // char *str = runesToStr(s, len, &ulen);
       //   printf("Found %s -> %.*s -> %f, dist %d\n", terms[i], len, str, score,
       //           dist);
       matches++;
@@ -199,7 +199,7 @@ int testDFAFilter() {
   char *prefixes[] = {"dos", "cb", "gang", "jez", "של", "שח", NULL};
   for (i = 0; prefixes[i] != NULL; i++) {
     //printf("prefix %d: %s\n", i, prefixes[i]);
-    runes = __strToRunes(prefixes[i], &rlen);
+    runes = strToRunes(prefixes[i], &rlen);
     DFAFilter fc = NewDFAFilter(runes, rlen, 1, 1);
 
     TrieIterator *it = TrieNode_Iterate(root, FilterFunc, StackPop, &fc);

--- a/src/tests/test_trie.c
+++ b/src/tests/test_trie.c
@@ -1,5 +1,6 @@
 #include "../trie/trie.h"
 #include "../trie/levenshtein.h"
+#include "../trie/rune_util.h"
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -38,41 +39,6 @@ FilterCode stepFilter(unsigned char b, void *ctx, int *matched,
 //     // sparseVector_free(nv);
 //     // return NULL;
 // }
-
-/* Convert a utf-8 string to constant width runes */ 
-rune *__strToRunes(char *str, size_t *len) {
-
-  ssize_t rlen = nu_strlen(str, nu_utf8_read);
-  uint32_t decoded[sizeof(uint32_t) * (rlen + 1)];
-
-  nu_readstr(str, decoded, nu_utf8_read);
-
-  rune *ret = calloc(rlen + 1, sizeof(rune));
-  for (int i = 0; i < rlen; i++) {
-    ret[i] = (rune)decoded[i] & 0x0000FFFF;
-  }
-  if (len)
-    *len = rlen;
-  
-  return ret;
-}
-
-/* Convert a rune string to utf-8 characters */
-char *__runesToStr(rune *in, size_t len, size_t *utflen) {
-
-  uint32_t unicode[len + 1];
-  for (int i = 0; i < len; i++) {
-    unicode[i] = (uint32_t)in[i] & 0x0000ffff;
-  }
-  unicode[len] = 0;
-
-  *utflen = nu_bytelen(unicode, nu_utf8_write);
-
-  char *ret = calloc(1, *utflen + 1);
-
-  nu_writestr(unicode, ret, nu_utf8_write);
-  return ret;
-}
 
 int __trie_add(TrieNode **n, char *str, float sc, TrieAddOp op) {
   size_t rlen;

--- a/src/tests/test_util.h
+++ b/src/tests/test_util.h
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #define TESTFUNC(f)                                            \
   printf("Testing %s ...\n------------------\n", __STRING(f)); \
@@ -31,7 +32,6 @@
 #define ASSERT_EQUAL_INT(x, y, ...)                                 \
   if (x != y) {                                                     \
     fprintf(stderr, "%s:%d: ", __FILE__, __LINE__);                 \
-    fprintf(stderr, "%d != %d: " __VA_ARGS__ "\n", (int)x, (int)y); \
     return -1;                                                      \
   }
 

--- a/src/tests/test_util.h
+++ b/src/tests/test_util.h
@@ -28,10 +28,11 @@
 
 #define ASSERT_STRING_EQ(s1, s2) ASSERT(!strcmp(s1, s2));
 
-#define ASSERT_EQUAL(x, y, ...)                                 \
-  if (x != y) {                                                     \
-    fprintf(stderr, "%s:%d: Assertion Failed " __VA_ARGS__ ": ", __FILE__, __LINE__);                 \
-    return -1;                                                      \
+#define ASSERT_EQUAL(x, y, ...)                                           \
+  if (x != y) {                                                           \
+    fprintf(stderr, "%s:%d: ", __FILE__, __LINE__);                       \
+    fprintf(stderr, "%f != %f: " __VA_ARGS__ "\n", (double)x, (double)y); \
+    return -1;                                                            \
   }
 
 #define FAIL(fmt, ...)                                                            \

--- a/src/tests/test_util.h
+++ b/src/tests/test_util.h
@@ -4,7 +4,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <inttypes.h>
 
 #define TESTFUNC(f)                                            \
   printf("Testing %s ...\n------------------\n", __STRING(f)); \
@@ -23,15 +22,15 @@
   }
 #define ASSERT(expr)                                                                       \
   if (!(expr)) {                                                                           \
-    fprintf(stderr, "%s:%d: Assertion '%s' Failed\n", __FILE__, __LINE__, __STRING(expr)); \
+    fprintf(stderr, "%s:%d Assertion '%s' Failed\n", __FILE__, __LINE__, __STRING(expr));  \
     return -1;                                                                             \
   }
 
 #define ASSERT_STRING_EQ(s1, s2) ASSERT(!strcmp(s1, s2));
 
-#define ASSERT_EQUAL_INT(x, y, ...)                                 \
+#define ASSERT_EQUAL(x, y, ...)                                 \
   if (x != y) {                                                     \
-    fprintf(stderr, "%s:%d: ", __FILE__, __LINE__);                 \
+    fprintf(stderr, "%s:%d: Assertion Failed " __VA_ARGS__ ": ", __FILE__, __LINE__);                 \
     return -1;                                                      \
   }
 

--- a/src/tests/titles.csv
+++ b/src/tests/titles.csv
@@ -1,2799 +1,2799 @@
 bhoj shala,1
 radhika balakrishnan,1
 ltm,1
-sterlite energy,1
+steRlite energy,1
 troll doll,11
-sonnontio,1
+sonNontiO,1
 nickelodeon netherlands kids choice awards,1
-jamaica national basketball team,5
+jamAica National basketball team,5
 clan mackenzie,1
-secure attention key,3
+secUre aTtention key,3
 template talk indo pakistani war of 1971,1
-hassan firouzabadi,2
+hasSan fIrouzabadi,2
 carter alan,1
-alan levy,1
+alaN levY,1
 tim severin,2
-faux pas derived from chinese pronunciation,1
+fauX pas derived from chinese pronunciation,1
 jruby,3
-tobias nielsén,1
+tobIas nIelsén,1
 avro 571 buffalo,1
-treasury stock,17
+treAsury stock,17
 שלום,10
-oxygen 19,1
+oxyGen 19,1
 ntru,4
-tennis racquet,1
+tenNis rAcquet,1
 place of birth,4
-council of canadians,1
+couNcil Of canadians,1
 urshu,1
-american hotel,1
+ameRican hotel,1
 dow corning corporation,3
-language based learning disability,3
+lanGuage based learning disability,3
 meri aashiqui tum se hi,30
-specificity,9
+speCificIty,9
 edward l hedden,1
-pelli chesukundam,2
+pelLi chEsukundam,2
 of love and shadows,4
-fort san felipe,2
+forT san felipe,2
 american express gold card dress of lizzy gardiner,4
-jovian,5
+jovIan,5
 kitashinagawa station,1
-radhi jaidi,1
+radHi jaIdi,1
 cordelia scaife may,2
-minor earth major sky,1
+minOr eaRth major sky,1
 bunty lawless stakes,1
-high capacity color barcode,3
+higH capAcity color barcode,3
 lyla lerrol,1
-crawford roberts,1
+craWford roberts,1
 collin balester,1
-ugo crousillat,1
+ugo crouSillat,1
 om prakash chautala,3
-izzy hoyland,1
+izzY hoyLand,1
 the poet,2
-daryl sabara,6
+darYl saBara,6
 aromatic acid,2
-reina sofia,1
+reiNa soFia,1
 swierczek masovian voivodeship,1
-housing segregation in the united states,2
+houSing Segregation in the united states,2
 karen maser,1
-scaptia beyonceae,2
+scaPtia Beyonceae,2
 kitakyushu city,1
-htc desire 610,4
+htc desiRe 610,4
 dostoevsky,3
-portal victorian era,1
+porTal vIctorian era,1
 bose–einstein correlations,3
-ralph hodgson,1
+ralPh hoDgson,1
 racquet club,2
-walter camp man of the year,1
+walTer cAmp man of the year,1
 australian movies,1
-k04he,1
+k04He,1
 australia–india relations,2
-john william howard thompson,1
+johN wilLiam howard thompson,1
 pro cathedral,1
-paddyfield pipit,2
+padDyfieLd pipit,2
 book finance,1
-ford maverick,10
+forD mavErick,10
 slurve,4
-mnozil brass,2
+mnoZil bRass,2
 fiesta 9 1/8 inch square luncheon plate sunflower,1
-korsi,1
+korSi,1
 draft 140th operations group,2
-camp,29
+camP,29
 series acceleration,1
-aljouf,1
+aljOuf,1
 democratic party of new mexico,2
-united kingdom general election debates 2010,2
+uniTed kIngdom general election debates 2010,2
 madura strait,2
-back examination,1
+bacK exaMination,1
 borgata,2
-il ritorno di tobia,3
+il RitorNo di tobia,3
 ovaphagous,1
-motörhead,9
+motÖrheaD,9
 hellmaster,1
-richard keynes,1
+ricHard Keynes,1
 cryogenic treatment,3
-monte porzio,1
+monTe poRzio,1
 transliteration of arabic,1
-anti catholic,2
+antI catHolic,2
 a very merry pooh year,2
-suffixes in hebrew,3
+sufFixes in hebrew,3
 barr body,16
-alaska constitution,1
+alaSka cOnstitution,1
 juan garrido,1
-yi lijun,1
+yi Lijun,1
 wawa inc,2
-endre kelemen,1
+endRe keLemen,1
 l brands,18
 lr44,1
 coat of arms of the nagorno karabakh republic,1
-antonino fernandez,1
+antOnino fernandez,1
 salisbury roller girls,1
-zayat,2
+zayAt,2
 ian meadows,2
-semigalia,1
+semIgaliA,1
 khloe and lamar,2
-holding,1
+holDing,1
 larchmont edgewater,1
-dynamic parcel distribution,6
+dynAmic Parcel distribution,6
 seaworld,30
-assistant secretary of war,1
+assIstanT secretary of war,1
 digital currency,14
-mazomanie wisconsin,1
+mazOmaniE wisconsin,1
 sujatha rangarajan,8
-street child,1
+strEet cHild,1
 anna sheehan,1
-violence jack,2
+vioLence jack,2
 santi solari,1
-template talk texas in the civil war,1
+temPlate talk texas in the civil war,1
 colorss foundation,1
-faucaria,1
+fauCaria,1
 alfred gardyne de chastelain,2
-tramp,1
+traMp,1
 cannington ontario,2
-penguinone,1
+penGuinoNe,1
 cardiac arrest,2
-summan grouper,1
+sumMan gRouper,1
 cyndis list,1
 cbs,2
 salminus brasiliensis,2
-kodiak bear,26
+kodIak bEar,26
 cinemascore,9
-phragmidium,1
+phrAgmidIum,1
 city of vultures,1
-lawrence g romo,1
+lawRence g romo,1
 chandni chowk to china,1
-scarp retreat,1
+scaRp reTreat,1
 rosses point,1
-carretera de cádiz,1
+carReterA de cádiz,1
 chamunda,8
-battle of stalingrad,1
+batTle oF stalingrad,1
 who came first,2
-salome,5
+salOme,5
 portuguese historical museum,3
-westfield sarasota square,1
+wesTfielD sarasota square,1
 muehrckes nails,3
-kennebec north carolina,1
+kenNebec north carolina,1
 american classical league,1
-how do you like them apples,1
+how do yOu like them apples,1
 mark halperin,20
-circo,1
+cirCo,1
 turner classic movies,2
-australian rules football in sweden,1
+ausTraliAn rules football in sweden,1
 household silver,3
-frank baird,1
+fraNk baIrd,1
 escape from east berlin,2
-a village romeo and juliet,1
+a vIllagE romeo and juliet,1
 wally nesbitt,6
-joseph renzulli,2
+josEph rEnzulli,2
 spalding gray,1
-dangaria kandha,1
+danGaria kandha,1
 pms asterisk,2
-openal,1
+opeNal,1
 romy haag,1
-mh message handling system,4
+mh MessaGe handling system,4
 pioneer 4,4
-hmcs stettler,1
+hmcS steTtler,1
 gangsta,10
-major third,4
+majOr thIrd,4
 joan osbourn,1
-mount columbia,2
+mouNt coLumbia,2
 active galactic nucleus,14
-robert clary,8
+robErt cLary,8
 eva pracht,1
-ion implantation,5
+ion implAntation,5
 rydell poepon,4
-baller blockin,2
+balLer bLockin,2
 enfield chase railway station,1
-serge aurier,13
+serGe auRier,13
 florin vlaicu,1
-van diemens land,9
+van diemEns land,9
 krishnapur bagalkot,1
-oleksandr zinchenko,96
+oleKsandR zinchenko,96
 collaborations,2
-hecla,2
+hecLa,2
 amber marshall,7
-inácio henrique de gouveia,1
+ináCio hEnrique de gouveia,1
 bronze age korea,1
 slc punk,5
 ryan jack,2
-clathrus ruber,6
+claThrus ruber,6
 angel of death,4
-valentines park,1
+valEntinEs park,1
 extra pyramidal,1
-kiami davael,1
+kiaMi daVael,1
 oleg i shuplyak,1
-nidum,2
+nidUm,2
 friendship of salem,2
-bèze,3
+bèzE,3
 arnold weinstock,1
-able,1
+ablE,1
 s d ugamchand,1
-the omega glory,2
+the omegA glory,2
 ami james,3
-denmark at the 1968 summer olympics,1
+denMark At the 1968 summer olympics,1
 kill me again,1
-richmond town square,1
+ricHmond town square,1
 guy domville,1
-jessica simpson,1
+jesSica Simpson,1
 kinship care,1
-brugge railway station,2
+bruGge rAilway station,2
 unobtainium,16
-carl johan bernadotte,3
+carL johAn bernadotte,3
 acacia concinna,5
-epinomis,1
+epiNomis,1
 interlachen country club,1
-compromise tariff,1
+comPromiSe tariff,1
 fairchild jk,1
-dog trainer,1
+dog traiNer,1
 brian dabul,1
 cai yong,1
 jezebel,7
-augarten porcelain,1
+augArten porcelain,1
 summerslam 1992,1
-ion andoni goikoetxea,2
+ion andoNi goikoetxea,2
 dominican church vienna,1
-iffhs worlds best club coach,2
+iffHs woRlds best club coach,2
 uruguayan presidential election 2009,2
-saving the queen,1
+savIng tHe queen,1
 un cadavre,1
-history of the jews in france,4
+hisTory Of the jews in france,4
 wbyg,1
-charles de brosses,2
+chaRles De brosses,2
 human weapon,2
-haunted castle,3
+hauNted Castle,3
 austin maestro,1
-search for extra terrestrial intelligence,1
+seaRch fOr extra terrestrial intelligence,1
 suwon,9
-cost per impression,1
+cosT per impression,1
 osney lock,1
-markus eriksson,1
+marKus eRiksson,1
 cultural depictions of tony blair,2
-erich kempka,3
+eriCh keMpka,3
 pornogrind,5
-chekhov,1
+cheKhov,1
 marilinda garcia,2
-hard drive,1
+harD driVe,1
 small arms,9
-exploration of north america,8
+expLoratIon of north america,8
 international korfball federation,1
-photographic lens design,4
+phoTograPhic lens design,4
 k hari prasad,1
-lebanese forces,3
+lebAnese forces,3
 greece at the 2004 summer olympics,1
-lets trim our hair in accordance with the socialist lifestyle,2
+letS triM our hair in accordance with the socialist lifestyle,2
 battle of cassinga,5
-donald and the wheel,1
+donAld aNd the wheel,1
 vti transmission,1
-gille chlerig earl of mar,1
+gilLe chLerig earl of mar,1
 heart of atlanta motel inc v united states,6
-oh yeah,3
+oh Yeah,3
 carol decker,5
-prajakta shukre,4
+praJakta shukre,4
 profiling,17
-thukima,1
+thuKima,1
 the great waldo search,1
-nick vincent,2
-the decision of the appeals jury is final and can only be overruled by a decision of the executive committee 2e,1
+nicK vinCent,2
+the decision of the appeals jury is final and can only be overruled by a decision of the eXecutIve committee 2e,1
 civilization board game,1
-erasmus+,1
+eraSmus+,1
 eden phillpotts,1
-unleash the beast,1
+unlEash The beast,1
 varoujan hakhbandian,1
-fermats last theorem,1
+ferMats Last theorem,1
 conan the indomitable,1
-vagrant records,1
+vagRant Records,1
 house of villehardouin,1
-zoneyesha ulatha,1
+zonEyeshA ulatha,1
 ashur bel nisheshu,1
-ten wijngaerde,2
+ten wijnGaerde,2
 lgi homes,1
-american nietzsche a history of an icon and his ideas,1
+ameRican nietzsche a history of an icon and his ideas,1
 european magpie,3
-pablo soto,1
+pabLo soTo,1
 terminiello v chicago,1
-vladimir cosma,2
+vlaDimir cosma,2
 battle of yunnan burma road,1
-ophirodexia,1
+ophIrodeXia,1
 thudar,1
-northern irish,2
+norThern irish,2
 bohemond of tarente,1
-anita moorjani,5
+aniTa moOrjani,5
 serra do gerês,1
-fort horsted,1
+forT horSted,1
 metre gauge,2
-stage show,3
+staGe shOw,3
 common flexor sheath of hand,2
-conall corc,1
+conAll cOrc,1
 array slicing,6
-schüfftan process,1
+schÜfftaN process,1
 anmol malik,3
 out cold,2
 antiknock,2
-moss force,1
+mosS forCe,1
 paul medhurst,1
-somonauk illinois,1
+somOnauk illinois,1
 george crum,11
-baby talk,6
+babY talK,6
 daniel mann,4
-vacuum flask,10
+vacUum fLask,10
 prostitution in the republic of ireland,5
-butch jones,7
+butCh joNes,7
 feminism in ukraine,1
-st marys church kilmore county wexford,1
+st Marys church kilmore county wexford,1
 sonny emory,1
-satsuma han,1
+satSuma Han,1
 elben,1
 the best of the rippingtons,3
 m3p,1
-boat sharing,1
+boaT shaRing,1
 iisco,1
-hoftoren,1
+hofToren,1
 cannabis in the united kingdom,6
-template talk germany districts saxony anhalt,1
+temPlate talk germany districts saxony anhalt,1
 jean baptiste dutrou bornier,1
-teylers museum,1
+teyLers Museum,1
 simons problem,2
-gerardus huysmans,1
+gerArdus huysmans,1
 pupillary distance,5
-jane lowe,1
+janE lowE,1
 palais de justice brussels,1
-hillsdale free will baptist college,1
+hilLsdalE free will baptist college,1
 raf wattisham,2
-parnataara,1
+parNataaRa,1
 jensen beach campus of the florida institute of technology,1
-scottish gypsy and traveller groups,3
+scoTtish gypsy and traveller groups,3
 cliffs shaft mine museum,3
-roaring forties,4
+roaRing Forties,4
 where in time is carmen sandiego?,2
-perfect field,1
+perFect Field,1
 rob schamberger,1
-lcd soundsystem,10
+lcd sounDsystem,10
 alan rathbone,26
-setup,1
+setUp,1
 gliding over all,4
-dastur,1
+dasTur,1
 flensburger brauerei,3
-berkeley global campus at richmond bay,1
+berKeley global campus at richmond bay,1
 kanakapura,1
-mineworkers union of namibia,1
+minEworkErs union of namibia,1
 tokneneng,3
-mapuche textiles,3
+mapUche Textiles,3
 peranakan beaded slippers,1
-goodra,2
+gooDra,2
 kanab ut,1
 the gold act 1968,4
 grey langur,1
-procol harum,5
+proCol hArum,5
 chris alexander,1
-ft walton beach metropolitan area,3
+ft WaltoN beach metropolitan area,3
 dimensionless quantity,16
-the science of mind,1
+the scieNce of mind,1
 alfons schone,1
-euparthenos nubilis,1
+eupArtheNos nubilis,1
 batrachotoxin,5
-fabric live 22,1
+fabRic lIve 22,1
 mchenry boatwright,1
-langney sports club,1
+lanGney Sports club,1
 akela jones,1
-lookout,2
+looKout,2
 matsuo tsurayaba,2
-general jackson,3
+genEral Jackson,3
 hair removal,14
-african party for the independence of cape verde,4
+afrIcan Party for the independence of cape verde,4
 replica trick,1
-bromfenac,2
+broMfenaC,2
 make someone happy,1
-sam pancake,1
+sam pancAke,1
 denys finch hatton,10
-latin rhythm albums,1
+latIn rhYthm albums,1
 main bronchus,1
-campidoglio,4
+camPidogLio,4
 cathaoirleach,1
-emress justina,1
+emrEss jUstina,1
 sulzbach hesse,1
-noncicatricial alopecia,1
+nonCicatRicial alopecia,1
 sylvan place,4
-stalag i c,1
+staLag i c,1
 league of extraordinary gentlemen,1
-sergey korolyov,2
+serGey kOrolyov,2
 serbian presidential election 1997,1
-barnes lake millers lake michigan,1
+barNes lAke millers lake michigan,1
 christmas island health centre,1
-dayton ballet,2
+dayTon bAllet,2
 gilles fauconnier,1
-harald svergja,1
+harAld sVergja,1
 joanna newsom discography,2
-astro xi yue hd,1
+astRo xi yue hd,1
 code sharing,3
-dreamcast vmu,1
+dreAmcasT vmu,1
 armand emmanuel du plessis duc de richelieu,1
-ecole supérieure des arts du cirque,2
+ecoLe suPérieure des arts du cirque,2
 gerry mulligan,12
-kaaka kaaka,1
+kaaKa kaAka,1
 mexico at the 2012 summer olympics,4
-bar wizards,2
+bar wizaRds,2
 christmas is almost here again,2
-sterling heights michigan,4
+steRling heights michigan,4
 gaultheria procumbens,3
-eben etzebeth,8
+ebeN etzEbeth,8
 viktorija Čmilytė,1
-los angeles county california,39
+los angeLes county california,39
 family entertainment,2
-quantum well,9
+quaNtum Well,9
 elton,1
-allan frewin jones,1
+allAn frEwin jones,1
 daniela ruah,32
-gkd legend,1
+gkd legeNd,1
 coffman–graham algorithm,1
-santa clara durango,1
+sanTa clAra durango,1
 brian protheroe,3
-crawler transporter,10
+craWler Transporter,10
 lakshman,3
-fes el bali,2
+fes el bAli,2
 mary a krupsak,1
-irish rugby football union,5
+iriSh ruGby football union,5
 neuropsychiatry,2
-josé pirela,1
+josÉ pirEla,1
 bonaire status referendum 2015,1
 it,2
 playhouse in the park,1
-alexander yakovlev,7
+aleXandeR yakovlev,7
 old bear,1
-graph tool,2
+graPh toOl,2
 merseyside west,1
-romanian armies in the battle of stalingrad,1
+romAnian armies in the battle of stalingrad,1
 dark they were and golden eyed,1
-aidan obrien,8
+aidAn obRien,8
 town and davis,1
-suum cuique,3
+suuM cuiQue,3
 german american day,2
-northampton county pennsylvania,3
+norThampTon county pennsylvania,3
 candidates of the south australian state election 2010,1
-venator marginatus,2
+venAtor Marginatus,2
 k60an,1
-template talk campaignbox seven years war european,1
+temPlate talk campaignbox seven years war european,1
 maravi,1
-flaithbertach ua néill,1
+flaIthbeRtach ua néill,1
 junction ohio,1
-dave walter,1
+davE walTer,1
 london transport board,1
-tuyuka,1
+tuyUka,1
 the moodys,3
-noel,3
+noeL,3
 eugen richter,1
-cowanshannock township armstrong county pennsylvania,1
+cowAnshaNnock township armstrong county pennsylvania,1
 pre columbian gold museum,1
-lac demosson,1
+lac demoSson,1
 lincosamides,9
-the vegas connection,1
+the vegaS connection,1
 stephen e harris,1
-alkali feldspar,2
+alkAli fEldspar,2
 brant hansen,1
-draft carnatic music stub,4
+draFt caRnatic music stub,4
 the chemicals between us,1
-blood and bravery,1
+bloOd anD bravery,1
 san diego flash,3
-covert channel,5
+covErt cHannel,5
 ernest w adams,1
-hills brothers coffee,1
+hilLs brOthers coffee,1
 cosmic background explorer,4
-international union of pure and applied physics,2
+intErnatIonal union of pure and applied physics,2
 vladimir kramnik,21
-hinterland,2
+hinTerlaNd,2
 tinker bell and the legend of the neverbeast,5
-ophisops jerdonii,1
+ophIsops jerdonii,1
 fine gold,1
-net explosive quantity,3
+net explOsive quantity,3
 miss colorado teen usa,3
-royal philharmonic orchestra discography,1
+royAl phIlharmonic orchestra discography,1
 elyazid maddour,1
-matthew kelly,2
+matThew Kelly,2
 templating language,1
-japan campaign,2
+japAn caMpaign,2
 barack obama on mass surveillance,2
-thomas r donahue,1
+thoMas r donahue,1
 old right,4
-spencer kimball,1
+speNcer Kimball,1
 golden kela awards,1
-blinn college,3
+bliNn coLlege,3
 w k simms,1
-quinto romano,1
+quiNto rOmano,1
 richard mulrooney,1
-mr backup z64,1
+mr BackuP z64,1
 monetization of us in kind food aid,1
-alex chilton,2
+aleX chiLton,2
 propaganda in the peoples republic of china,4
-jiří skalák,8
+jiřÍ skaLák,8
 m5 stuart tank,1
-template talk ap defensive players of the year,1
+temPlate talk ap defensive players of the year,1
 crisis,2
-azuchi momoyama period,1
+azuChi mOmoyama period,1
 care and maintenance,2
-a$ap mob,3
+a$aP mob,3
 near field communication,111
-hips hips hooray,1
+hipS hipS hooray,1
 promotional cd,1
-andean hairy armadillo,1
+andEan hAiry armadillo,1
 trigueros del valle,1
-elmwood illinois,1
+elmWood Illinois,1
 cantonment florida,2
-margo t oge,1
+marGo t Oge,1
 national park service,36
-monongalia county ballpark,3
+monOngalIa county ballpark,3
 bakemonogatari,6
-felicia michaels,1
+felIcia Michaels,1
 institute of oriental studies of the russian academy of sciences,2
-economy of eritrea,2
+ecoNomy Of eritrea,2
 vincenzo chiarenza,1
-microelectronics,4
+micRoeleCtronics,4
 fresno state bulldogs mens basketball,1
-maotou,1
+maoTou,1
 blokely,1
-duplicati,3
+dupLicatI,3
 goud,2
-niki reiser,1
+nikI reiSer,1
 edward leonard ellington,1
-jaswant singh of marwar,1
+jasWant Singh of marwar,1
 biharsharif,1
-dynasty /trackback/,1
+dynAsty /trackback/,1
 machrihanish,4
-jay steinberg,1
+jay steiNberg,1
 peter luger steak house,3
-palookaville,1
+palOokavIlle,1
 ferrari grand prix results,2
-bankruptcy discharge,2
+banKruptCy discharge,2
 mike mccue,2
-nuestra belleza méxico 2013,2
+nueStra Belleza méxico 2013,2
 alex neal bullen,1
-gus macdonald baron macdonald of tradeston,2
+gus macdOnald baron macdonald of tradeston,2
 florida circuit court,1
-haarp,2
+haaRp,2
 v pudur block,1
-grocer,1
+groCer,1
 shmuel hanavi,1
-isaqueena falls,2
+isaQueenA falls,2
 jean moulin university,1
-final fantasy collection,1
+finAl faNtasy collection,1
 template talk american frontier,1
-chex quest,4
+cheX queSt,4
 muslim students association,2
-marco pique,1
+marCo piQue,1
 jinja safari,1
-the collection,9
+the collEction,9
 urban districts of germany,5
-rajiv chilaka,1
+rajIv chIlaka,1
 zion,2
 vf 32,1
 united states commission on civil rights,2
-zazam,1
+zazAm,1
 barnettas,4
-rebecca blasband,1
+rebEcca Blasband,1
 lincoln village,1
-film soundtracks,1
+filM souNdtracks,1
 angus t jones,77
-snuppy,3
+snuPpy,3
 w/indexphp,30
-file talk american world war ii senior military officials 1945jpeg,1
+filE talK american world war ii senior military officials 1945jpeg,1
 worship leader,1
-ein qiniya,1
+ein qiniYa,1
 buxton maine,1
-matt dewitt,1
+matT dewItt,1
 béla bollobás,3
-earlysville union church,1
+earLysviLle union church,1
 bae/mcdonnell douglas harrier ii gr9,1
-californian condor,2
+calIfornIan condor,2
 progressive enhancement,15
-its not my time,4
+its not My time,4
 ecw on tnn,2
-ihop,36
+ihoP,36
 aeronautical chart,1
-clique width,1
+cliQue wIdth,1
 fuengirola,8
-archicebus achilles,2
+arcHicebUs achilles,2
 comparison of alcopops,1
-carla anderson hills,1
+carLa anDerson hills,1
 roanoke county virginia,2
-jaílson alves dos santos,1
+jaíLson Alves dos santos,1
 rameses revenge,1
-kaycee stroh,5
+kayCee sTroh,5
 les experts,1
-niels skousen,1
+nieLs skOusen,1
 apollo hoax theories,1
-mercedes w204,2
+merCedes w204,2
 enhanced mitigation experience toolkit,15
-bert barnes,1
+berT barNes,1
 serializability,6
-ten plagues of egypt,1
+ten plagUes of egypt,1
 joe l brown,1
-category talk high importance chicago bears articles,1
+catEgory talk high importance chicago bears articles,1
 stephen caffrey,3
-european border surveillance system,2
+eurOpean border surveillance system,2
 achytonix,1
-m2 machine gun,1
+m2 MachiNe gun,1
 gurieli,1
-kunefe,1
+kunEfe,1
 m33 helmet,3
-little carmine,1
+litTle cArmine,1
 smush,3
-josé horacio gómez,1
+josÉ horAcio gómez,1
 product recall,1
-egger,1
+eggEr,1
 wisconsin highway 55,1
-harbledown,1
+harBledoWn,1
 low copy repeats,1
-curt gentry,1
+curT genTry,1
 united colors of benetton,1
-adiabatic shear band,2
+adiAbatiC shear band,2
 pea galaxy,1
-where are you now,1
+wheRe arE you now,1
 dils,1
-surprise s1,1
+surPrise s1,1
 senate oceans caucus,2
-windsor new hampshire,1
+winDsor New hampshire,1
 a hawk and a hacksaw,1
-i love it loud,2
+i lOve iT loud,2
 milbcom,1
-old world vulture,7
+old worlD vulture,7
 camara v municipal court of city and county of san francisco,1
-ski dubai,1
+ski dubaI,1
 st cyprians school,2
-aibo,1
+aibO,1
 ticker symbol,2
-hendrik houthakker,1
+henDrik Houthakker,1
 shivering,5
-jacob arminius,1
+jacOb arMinius,1
 mowming,1
-panjiva,2
+panJiva,2
 namco libble rabble,5
-rudolph bing,1
+rudOlph Bing,1
 sindhi cap,2
-logician,1
+logIcian,1
 ford xa falcon,2
-the sunny side up show,1
+the sunnY side up show,1
 helen adams,2
-kharchin,1
+khaRchin,1
 brittany maynard,13
-kim kyu jong,1
+kim kyu Jong,1
 messier 103,3
-leon boiler,1
+leoN boiLer,1
 the rapeman,1
-twa flight 3,4
+twa fligHt 3,4
 leading ladies,1
-delta octantis,2
+delTa ocTantis,2
 qatari nationality law,1
-lionel cripps,1
+lioNel cRipps,1
 josé daniel carreño,1
-crypsotidia longicosta,1
+cryPsotiDia longicosta,1
 polish falcons,1
-highlands north gauteng,1
+higHlandS north gauteng,1
 the florida channel,1
-oreste barale,1
+oreSte bArale,1
 ghazi of iraq,2
-charles grandison finney,4
+chaRles Grandison finney,4
 ahmet ali,1
-abbeytown,1
+abbEytowN,1
 caribou,3
 big two,2
 alien,14
-aslantaş dam,3
+aslAntaş dam,3
 theme of the traitor and the hero,1
-vladimir solovyov,1
+vlaDimir solovyov,1
 laguna ojo de liebre,1
-clive barton,1
+cliVe baRton,1
 ebrahim daoud nonoo,1
-richard goodwin keats,2
+ricHard Goodwin keats,2
 back to the who tour 51,1
-entertainmentwise,1
+entErtaiNmentwise,1
 ja preston,1
-john astin,19
+johN astIn,19
 strict function,1
 cam ranh international airport,2
 gary pearson,1
-sven väth,8
+sveN vätH,8
 toad,6
-johnny pace,1
+johNny pAce,1
 hunt stockwell,1
-rolando schiavi,1
+rolAndo Schiavi,1
 claudia grassl,1
-oxford nova scotia,1
+oxfOrd nOva scotia,1
 maryland sheep and wool festival,1
-conquest of bread,1
+conQuest of bread,1
 erevan,1
-comparison of islamic and jewish dietary laws,11
+comParisOn of islamic and jewish dietary laws,11
 sheila burnford,1
-estevan payan,1
+estEvan Payan,1
 ocean butterflies international,7
-the royal winnipeg rifles,1
+the royaL winnipeg rifles,1
 green goblin in other media,2
-video gaming in japan,8
+vidEo gaMing in japan,8
 church of the guanche people,4
-gustav hartlaub,2
+gusTav hArtlaub,2
 ian mcgeechan,4
-hammer and sickle,17
+hamMer aNd sickle,17
 konkiep river,1
-ceri richards,1
+cerI ricHards,1
 decentralized,2
-depth psychology,3
+depTh psYchology,3
 centennial parkway,1
-yugoslav monitor vardar,1
+yugOslav monitor vardar,1
 battle of bobbili,2
-magnus iii of sweden,1
+magNus iIi of sweden,1
 england c national football team,2
-thuraakunu,1
+thuRaakuNu,1
 bab el ehr,1
 koi,1
 cully wilson,1
-money laundering,1
+monEy laUndering,1
 stirling western australia,1
-jennifer dinoia,1
+jenNifer dinoia,1
 eureka street,1
-message / call my name,1
+mesSage / call my name,1
 make in maharashtra,4
-huckleberry creek patrol cabin,1
+hucKlebeRry creek patrol cabin,1
 almost famous,5
-truck nuts,4
+truCk nuTs,4
 vocus communications,1
-gikwik,1
+gikWik,1
 battle of bataan,4
-confluence pennsylvania,2
+conFluenCe pennsylvania,2
 islander 23,1
-mv skorpios ii,1
+mv SkorpIos ii,1
 single wire earth return,1
-politics of odisha,1
+polItics of odisha,1
 crédit du nord,3
-piper methysticum,2
+pipEr meThysticum,2
 coble,2
-kathleen a mattea,1
+katHleen a mattea,1
 coachella valley music and arts festival,50
-tooniverse,1
+tooNiverSe,1
 spofforth castle,1
-arabian knight,2
+araBian Knight,2
 two airlines policy,1
-hinduja group,17
+hinDuja Group,17
 swagg alabama,1
-portuguese profanity,1
+porTugueSe profanity,1
 loomis gang,2
-nina veselova,2
+ninA vesElova,2
 aegyrcitherium,1
-bees in paradise,1
+beeS in Paradise,1
 béládys anomaly,3
-badalte rishtey,1
+badAlte Rishtey,1
 first bank fc,1
-cystoseira,1
+cysToseiRa,1
 red book of endangered languages,1
-rose,6
+rosE,6
 terry mcgurrin,3
-jason hawke,1
+jasOn haWke,1
 peter chernin,1
 tu 204,1
 the man who walked alone,1
-tool grade steel,1
+tooL graDe steel,1
 wrist spin,1
 one step forward two steps back,1
 theodor boveri,1
-heunginjimun,1
+heuNginjImun,1
 fama–french three factor model,34
-billy whitehurst,1
+bilLy whItehurst,1
 rip it up,4
-red lorry yellow lorry,4
+red lorrY yellow lorry,4
 nao tōyama,8
-general macarthur,1
+genEral Macarthur,1
 rabi oscillation,2
-devín,1
+devÍn,1
 olympus e 420,1
-hydra entertainment,1
+hydRa enTertainment,1
 chris cheney,3
-rio all suite hotel and casino,3
+rio all Suite hotel and casino,3
 the death gate cycle,2
-fatima,1
+fatIma,1
 kamomioya shrine,1
-five nights at freddys 3,14
+fivE nigHts at freddys 3,14
 the broom of the system,3
-robert blincoe,1
+robErt bLincoe,1
 history of wells fargo,9
-pinocytosis,4
+pinOcytoSis,4
 leaf phoenix,1
-wxmw,2
+wxmW,2
 tommy henriksen,13
-geri halliwell discography,2
+gerI halLiwell discography,2
 blade runneri have seen things you would not believe,1
-madhwa brahmins,1
+madHwa bRahmins,1
 i/o ventures,1
-edorisi master ekhosuehi,2
+edoRisi Master ekhosuehi,2
 junior orange bowl,1
-khit,2
+khiT,2
 sue jones,1
-immortalized,35
+immOrtalIzed,35
 city building series,4
-quran translation,1
+qurAn trAnslation,1
 united states consulate,1
-dose response relationship,1
+dosE resPonse relationship,1
 caitriona,1
-colocolo,21
+colOcolo,21
 medea class destroyer,1
-vaastav,1
+vaaStav,1
 etc1,1
-john altoon,2
+johN altOon,2
 thylacine,113
-cycling at the 1924 summer olympics,1
+cycLing At the 1924 summer olympics,1
 margaret nagle,1
-superpower,57
+supErpowEr,57
 gülşen,1
-anthems to the welkin at dusk,4
+antHems To the welkin at dusk,4
 yerevan united fc,1
-the family fang,14
+the famiLy fang,14
 domain,4
-high speed rail in india,14
+higH speEd rail in india,14
 trifolium pratense,7
-florida mountains,2
+floRida Mountains,2
 national city corp,5
-length of us participation in major wars,2
+lenGth oF us participation in major wars,2
 acacia acanthoclada,1
-offas dyke path,2
+offAs dyKe path,2
 enduro,7
-howard center,1
+howArd cEnter,1
 littlebits,4
-plácido domingo jr,1
+pláCido Domingo jr,1
 hookdale illinois,1
 the love language,1
 cupids arrows,1
-dc talk,7
+dc Talk,7
 maesopsis eminii,1
-here comes goodbye,1
+herE comEs goodbye,1
 freddie foreman,5
-marvel comics publishers,1
+marVel cOmics publishers,1
 consolidated city–county,5
-countess marianne bernadotte of wisborg,1
+couNtess marianne bernadotte of wisborg,1
 los angeles baptist high school,1
-maglalatik,1
+magLalatIk,1
 deo,2
-meilichiu,1
+meiLichiU,1
 wade coleman,1
-monster soul,2
+monSter Soul,2
 julion alvarez,2
-platinum 166,1
+plaTinum 166,1
 shark week,12
-hossbach memorandum,4
+hosSbach memorandum,4
 jack c massey,3
-ardore,1
+ardOre,1
 philosopher king,5
-dynamic random access memory,5
+dynAmic Random access memory,5
 bronze age in southeastern europe,1
-tamil films of 2012,1
+tamIl fiLms of 2012,1
 nathalie cely,1
-italian capital,1
+itaLian Capital,1
 optic tract,3
-shakti kumar,1
+shaKti kUmar,1
 who killed bruce lee,1
-parlement of brittany,3
+parLemenT of brittany,3
 san juan national historic site,2
-livewell,2
+livEwell,2
 template talk om,1
-al bell,2
+al Bell,2
 pzl w 3 sokół,8
-durrës rail station,3
+durRës rAil station,3
 david stubbs,1
-pharmacon,3
+phaRmacoN,3
 railfan,7
-comics by country,2
+comIcs bY country,2
 cullen baker,1
-maximum subarray problem,19
+maxImum Subarray problem,19
 outlaws and angels,1
-paradise falls,2
+parAdise falls,2
 mathias pogba,28
-donella meadows,4
+donElla Meadows,4
 john leconte,2
-swaziland national football team,7
+swaZilanD national football team,7
 gabriele detti,2
-if ever youre in my arms again,1
+if Ever Youre in my arms again,1
 christian basso,1
-helen shapiro,7
+helEn shApiro,7
 taisha abelar,1
-fluid dynamics,1
+fluId dyNamics,1
 ernest wilberforce,1
-kocaeli university,2
+kocAeli University,2
 british m class submarine,1
-modern woodmen of america,1
+modErn wOodmen of america,1
 las posadas,3
-federal budget of germany,2
+fedEral Budget of germany,2
 liberation front of chad,1
-sandomierz,5
+sanDomieRz,5
 ap italian language and culture,1
-manuel gonzález,1
+manUel gOnzález,1
 georgian military road,2
-clear creek county colorado,1
+cleAr crEek county colorado,1
 matt clark,2
-test tube,18
+tesT tubE,18
 ak 47,1
-diège,1
+dièGe,1
 london school of economics+,1
-michael york,14
+micHael York,14
 half eagle,6
-strike force,1
+strIke fOrce,1
 type 054 frigate,2
-sino indian relations,7
+sinO indIan relations,7
 fern,3
-louvencourt,1
+louVencoUrt,1
 ghb receptor,2
-chondrolaryngoplasty,2
+choNdrolAryngoplasty,2
 andrew lewer,1
-ross king,1
+rosS kinG,1
 colpix records,1
-october 28,1
+octOber 28,1
 tatsunori hara,1
-rossana lópez león,1
+rosSana López león,1
 haskell texas,3
-tower subway,2
+towEr suBway,2
 waspstrumental,1
-template talk nba anniversary teams,1
+temPlate talk nba anniversary teams,1
 george leo leech,1
-still nothing moves you,1
+stiLl noThing moves you,1
 blood cancer,3
-buffy lynne williams,1
+bufFy lyNne williams,1
 dpgc u know what im throwin up,1
-daniel nadler,1
+danIel nAdler,1
 khalifa sankaré,2
-homo genus,1
+homO genUs,1
 garðar thór cortes,3
-veyyil,1
+veyYil,1
 matt dodge,1
-hipponix subrufus,1
+hipPonix subrufus,1
 anostraca,1
-hartshill park,1
+harTshilL park,1
 purple acid phosphatases,1
-austromyrtus dulcis,1
+ausTromyRtus dulcis,1
 shamirpet lake,1
-favila of asturias,2
+favIla oF asturias,2
 acute gastroenteritis,1
-dalton cache pleasant camp border crossing,1
+dalTon cAche pleasant camp border crossing,1
 urobilinogen,13
-ss kawartha park,1
+ss KawarTha park,1
 professional chess association,1
-species extinction,1
+speCies Extinction,1
 gapa hele bi sata,1
-phyllis lyon and del martin,1
+phyLlis Lyon and del martin,1
 uk–us extradition treaty of 2003,1
-a woman killed with kindness,1
+a wOman Killed with kindness,1
 how bizarre,1
-norm augustine,1
+norM augUstine,1
 geil,1
-volleyball at the 2015 southeast asian games,2
+volLeybaLl at the 2015 southeast asian games,2
 jim ottaviani,1
-chekmagushevskiy district,1
+cheKmaguShevskiy district,1
 information search process,2
-queer,63
+queEr,63
 william pidgeon,1
-amelia adamo,1
+ameLia aDamo,1
 nato ouvrage "g",1
-tamsin beaumont,1
+tamSin bEaumont,1
 economy of syria,13
-douglas dc 8 20,1
+douGlas Dc 8 20,1
 tama and friends,4
-pringles,22
+priNgles,22
 kannada grammar,7
-lotoja,1
+lotOja,1
 peony,1
-bmmi,1
+bmmI,1
 eurovision song contest 1992,11
-cerro blanco metro station,1
+cerRo blAnco metro station,1
 sherlock the riddle of the crown jewels,4
-dorsa cato,1
+dorSa caTo,1
 nkg2d,8
-specific heat,6
+speCific heat,6
 nokia 6310i,2
-tergum,2
+terGum,2
 bahai temple,1
-dal segno,5
+dal segnO,5
 leigh chapman,2
-tupolev tu 144,60
+tupOlev Tu 144,60
 flight of ideas,1
-rita montaner,1
+ritA monTaner,1
 vivien a schmidt,1
-battle of the treasury islands,2
+batTle oF the treasury islands,2
 three kinds of evil destination,1
-richlite,1
+ricHlite,1
 medinilla,2
-timeline of aids,1
+timEline of aids,1
 colin renfrew baron renfrew of kaimsthorn,2
-hélène rollès,1
+hélÈne rOllès,1
 pedro winter,1
-sabine free state,1
+sabIne fRee state,1
 brzeg,1
-palisades park,1
+palIsadeS park,1
 gas gangrene,11
-dotyk,2
+dotYk,2
 daniela kix,1
-canna,16
+canNa,16
 property list,9
 john hamburg,1
 dunk island,5
-albreda,1
+albReda,1
 scammed yankees,1
-wireball,3
+wirEball,3
 junior 4,1
-absolutely anything,15
+absOluteLy anything,15
 linux operating system,1
-solsbury hill,15
+solSbury hill,15
 notopholia,1
-scottish heraldry,2
+scoTtish heraldry,2
 template talk paper data storage media,1
-category talk religion in ancient sparta,1
+catEgory talk religion in ancient sparta,1
 category talk cancer deaths in puerto rico,1
-mid michigan community college,2
+mid michIgan community college,2
 tvb anniversary awards,1
-frederick taylor gates,1
+freDericK taylor gates,1
 omoiyari yosan,3
-journal of the physical society of japan,1
+jouRnal Of the physical society of japan,1
 kings in the corner,2
-nungua,1
+nunGua,1
 amerika,4
-pacific marine environmental laboratory,1
+pacIfic Marine environmental laboratory,1
 the thought exchange,1
-italian bee,5
+itaLian Bee,5
 roma in spain,1
-sirinart,1
+sirInart,1
 crandon wisconsin,1
-shubnikov–de haas effect,6
+shuBnikoV–de haas effect,6
 portrait of maria portinari,4
-colin mcmanus,1
+colIn mcManus,1
 universal personal telecommunications,1
-royal docks,4
+royAl doCks,4
 brecon and radnorshire,3
-eilema caledonica,1
+eilEma cAledonica,1
 chalon sur saône,8
-toyota grand hiace,1
+toyOta gRand hiace,1
 sophorose,1
-semirefined 2bwax,1
+semIrefiNed 2bwax,1
 mechanics institute chess club,1
-the culture high,2
+the cultUre high,2
 dont wake me up,1
-transcaucasian mole vole,1
+traNscauCasian mole vole,1
 harry zvi tabor,1
-vhs assault rifle,1
+vhs assaUlt rifle,1
 playing possum,2
-omar minaya,2
+omaR minAya,2
 private university,1
-yuki togashi,3
+yukI togAshi,3
 ski free,2
-say no more,1
+say no mOre,1
 diving at the 1999 summer universiade,1
-armando sosa peña,1
+armAndo Sosa peña,1
 timur tekkal,1
-jura elektroapparate,1
+jurA eleKtroapparate,1
 pornographic magazine,1
-tukur yusuf buratai,1
+tukUr yuSuf buratai,1
 keep on moving,1
-laboulbeniomycetes,1
+labOulbeNiomycetes,1
 chiropractor solve problems,1
-mark s allen,3
+marK s aLlen,3
 committees of the european parliament,4
-blondie,7
+bloNdie,7
 veblungsnes,1
-bank vault,10
+banK vauLt,10
 smiling irish eyes,1
-robert kalina,2
+robErt kAlina,2
 polarization ellipse,2
-huntingdon priory,1
+hunTingdOn priory,1
 energy in the united kingdom,34
-hamble,1
+hamBle,1
 raja sikander zaman,1
-perigea hippia,1
+perIgea Hippia,1
 college of liberal arts and sciences,1
-bootblock,1
+booTblocK,1
 nato reporting names,2
-the serpentwar saga,1
+the serpEntwar saga,1
 reformed churches in the netherlands,1
-collaborative document review,4
+colLaborAtive document review,4
 combat mission beyond overlord,3
-vlra,2
+vlrA,2
 pat st john,1
-oceanid,5
+oceAnid,5
 itapetinga,1
-insane championship wrestling,9
+insAne cHampionship wrestling,9
 nathaniel gorham,1
-estadio metropolitano de fútbol de lara,2
+estAdio Metropolitano de fútbol de lara,2
 william of saint amour,2
 new york drama critics circle award,1
 alliant rq 6 outrider,2
-ilsan,1
+ilsAn,1
 top model po russki,1
-woolens,1
+wooLens,1
 rutledge minnesota,1
-joigny coach crash,2
+joiGny cOach crash,2
 zhou enlai the last perfect revolutionary,1
-the theoretical minimum,1
+the theoRetical minimum,1
 arrow security,1
-john shelton wilder,2
+johN sheLton wilder,2
 jasdf,2
-katie may,2
+katIe maY,2
 american jewish military history project,1
-business professionals of america,1
+busIness professionals of america,1
 questioned document examination,5
-motorola a760,1
+motOrola a760,1
 american steel & wire,1
-louis armstrong at the crescendo vol 1,1
+louIs arMstrong at the crescendo vol 1,1
 edward vernon,3
-maria taipaleenmäki,1
+marIa taIpaleenmäki,1
 margical history tour,2
 jar jar,1
 australian oxford dictionary,2
-revenue service,2
+revEnue Service,2
 odoardo farnese hereditary prince of parma,1
-weekend in new england,1
+weeKend In new england,1
 laurence harbor new jersey,2
-aramark tower,1
+araMark Tower,1
 stealers wheel,1
-cephalon,1
+cepHalon,1
 dawnguard,1
-saintsbury,2
+saiNtsbuRy,2
 saint fuscien,1
-ryoko kuninaka,1
+ryoKo kuNinaka,1
 farm to market road 1535,1
-alan kennedy,2
+alaN kenNedy,2
 esteban casagolda,1
-shin angyo onshi,1
+shiN angYo onshi,1
 william gowland,1
-eastern religions,6
+easTern Religions,6
 kenny lala,1
-alphonso davies,1
+alpHonso davies,1
 tadamasa hayashi,1
-meet the parents,2
+meeT the parents,2
 calvinist church,1
-ristorante paradiso,1
+risToranTe paradiso,1
 jose joaquim champalimaud,1
-olis,1
+oliS,1
 mill hill school,2
-lockroy,1
+locKroy,1
 battle of princeton,10
-cent,8
+cenT,8
 brough superior ss80,1
-ras al khaima club,3
+ras al kHaima club,3
 washington international university,3
-bradley kasal,2
+braDley Kasal,2
 miguel Ángel varvello,1
-oxygen permeability,1
+oxyGen pErmeability,1
 femoral circumflex artery,1
-golden sun dark dawn,4
+golDen sUn dark dawn,4
 pusarla sindhu,1
-toyota winglet,1
+toyOta wInglet,1
 wind profiler,1
-montefiore medical center,2
+monTefioRe medical center,2
 template talk guitar hero series,3
-little leaf linden,1
+litTle lEaf linden,1
 ramana,4
-islam in the czech republic,2
+islAm in the czech republic,2
 manuel vitorino,1
-joseph radetzky von radetz,3
+josEph rAdetzky von radetz,3
 francois damiens,1
-parasite fighter,1
+parAsite fighter,1
 friday night at st andrews,3
-hurbazum,1
+hurBazum,1
 haidhausen,1
-petabox,2
+petAbox,2
 salmonella enteritidis,2
-matthew r denver,1
+matThew R denver,1
 de la salle,1
-anti terrorism act 2015,6
+antI terRorism act 2015,6
 brugsen,1
-mountain times,1
+mouNtain times,1
 columbia basin project,1
-common wallaroo,2
+comMon wAllaroo,2
 clepsis brunneograpta,1
 red hot + dance,1
 mao fumei,1
-dark shrew,1
+darK shrEw,1
 coach,8
-come saturday morning,1
+comE satUrday morning,1
 aanmai thavarael,1
-hellenia,1
+helLenia,1
 donate life america,2
-plot of beauty and the beast toronto musical,1
+ploT of Beauty and the beast toronto musical,1
 births in 1243,3
-main page/wiki/portal technology,8
+maiN pagE/wiki/portal technology,8
 cambridgeshire archives and local studies,1
-big pines california,1
+big pineS california,1
 pegasus in popular culture,4
-baron glendonbrook,1
+barOn glEndonbrook,1
 your face sounds familiar,5
-boom tube,2
+booM tubE,2
 richard gough,8
-the new beginning in niigata,3
+the new Beginning in niigata,3
 american academy of health physics,1
-plain,9
+plaIn,9
 tushino airfield,1
-king george v coronation medal,1
+kinG geoRge v coronation medal,1
 geologic overpressure,1
-seille,1
+seiLle,1
 calorimeter,25
-french civil service,1
+freNch cIvil service,1
 david l paterson,1
-chinese gunboat chung shan,2
+chiNese Gunboat chung shan,2
 rhizobium inoculants,1
-wizard,4
+wizArd,4
 baghestan,1
-paustian house,2
+pauStian house,2
 ellen pompeo,55
-damien williams,1
+damIen wIlliams,1
 tomoe tamiyasu,1
-acute epithelial keratitis,1
+acuTe epIthelial keratitis,1
 casey abrams,8
-mendozite,1
+menDozitE,1
 kantian ethics,2
-mcclure syndicate,1
+mccLure Syndicate,1
 tokyo metro,6
-cuisine of guinea bissau,1
+cuiSine Of guinea bissau,1
 mossberg 500,18
-mollie gillen,1
+molLie gIllen,1
 above and beyond party,1
-joey carbone,1
+joeY carBone,1
 faulkner state community college,1
-tetsuya ishikawa,1
+tetSuya Ishikawa,1
 electric flag,3
-meet the feebles,2
+meeT the feebles,2
 kplm,1
-when we were twenty one,1
+wheN we Were twenty one,1
 horus bird,2
-youth in revolt,8
+youTh in revolt,8
 spongebob squarepants revenge of the flying dutchman,3
-ehow,5
+ehoW,5
 nikos xydakis,2
-ziprasidone,19
+zipRasidOne,19
 ulsan airport,1
-flechtingen,1
+fleChtinGen,1
 dave christian,3
-delaware national guard,1
+delAware national guard,1
 skaria thomas,1
-iraca,1
+iraCa,1
 kkhi,2
-swimming at the 2015 world aquatics championships – mens 1500 metre freestyle,2
+swiMming at the 2015 world aquatics championships – mens 1500 metre freestyle,2
 crossing lines,37
-john du cane,1
+johN du Cane,1
 i8,1
-bauer pottery,1
+bauEr poTtery,1
 affinity sutton,4
-lotus 119,1
+lotUs 119,1
 uss arleigh burke,1
-palmar interossei,2
+palMar iNterossei,2
 nofx discography,4
-bwia west indies airways,3
+bwiA wesT indies airways,3
 gopala ii,1
-north fork correctional facility,1
+norTh foRk correctional facility,1
 szeged 2011,1
-milligram per cent,2
+milLigraM per cent,2
 halas and batchelor,1
-what the day owes the night,1
+whaT the day owes the night,1
 sighișoara medieval festival,5
-scarning railway station,1
+scaRning railway station,1
 cambridge hospital,1
-amnesia labyrinth,2
+amnEsia Labyrinth,2
 cokie roberts,7
-savings identity,3
+savIngs Identity,3
 pravia,1
-mcgrath,4
+mcgRath,4
 pakistan boy scouts association,1
-dan carpenter,2
+dan carpEnter,2
 marikina–infanta highway,2
-genetic analysis,2
+genEtic Analysis,2
 template talk ohio state university,1
-thomas chamberlain,4
+thoMas cHamberlain,4
 moe book,1
-coyote waits,1
+coyOte wAits,1
 black protestant,1
-neetu singh,19
+neeTu siNgh,19
 mahmoud sarsak,1
-casa loma,28
+casA lomA,28
 bedivere,8
-boundary park,2
+bouNdary park,2
 danger danger,14
-jennifer coolidge,49
+jenNifer coolidge,49
 pop ya collar,1
-collaboration with the axis powers during world war ii,10
+colLaborAtion with the axis powers during world war ii,10
 greenskeepers,1
-the dukes children,1
+the dukeS children,1
 alaska off road warriors,1
-twenty five satang coin,1
+tweNty fIve satang coin,1
 template talk private equity investors,2
-american red cross,24
+ameRican red cross,24
 jason shepherd,1
-georgetown college,2
+geoRgetoWn college,2
 ocean countess,1
-ammonium magnesium phosphate,1
+ammOnium magnesium phosphate,1
 community supported agriculture,5
-philosophy of suicide,4
+phiLosopHy of suicide,4
 yard ramp,2
-captain germany,1
+capTain Germany,1
 bob klapisch,1
-i will never let you down,2
+i wIll nEver let you down,2
 february 11,6
-ron dennis,13
+ron dennIs,13
 rancid,16
 the mall blackburn,1
 south high school,6
-charles allen culberson,1
+chaRles Allen culberson,1
 organizational behavior,66
-automatic route selection,1
+autOmatiC route selection,1
 uss the sullivans,9
-yo no creo en los hombres,1
+yo No crEo en los hombres,1
 janet,1
-serena armstrong jones viscountess linley,3
+serEna aRmstrong jones viscountess linley,3
 louisiana–lafayette ragin cajuns mens basketball,1
-flower films,1
+floWer fIlms,1
 michelle ellsworth,1
-norbertine rite,2
+norBertiNe rite,2
 spanish mump,1
-shah jahan,67
+shaH jahAn,67
 fraser coast region,1
-matt cornwell,1
+matT corNwell,1
 nra,1
-crested butte mountain resort,1
+creSted Butte mountain resort,1
 college football playoff national championship,2
-craig heaney,4
+craIg heAney,4
 devil weed,1
-satsuki sho,1
+satSuki Sho,1
 jordaan brown,1
-little annie,4
+litTle aNnie,4
 thiha htet aung,1
-the disreputable history of frankie landau banks,1
+the disrEputable history of frankie landau banks,1
 mickey lewis,1
-eldar nizamutdinov,1
+eldAr niZamutdinov,1
 m1825 forage cap,1
-antonina makarova,1
+antOnina makarova,1
 mopani district municipality,2
-al jahra sc,1
+al Jahra sc,1
 chaim topol,4
-tum saath ho jab apne,1
+tum saatH ho jab apne,1
 piff the magic dragon,7
-imagining argentina,1
+imaGininG argentina,1
 ni 62,1
-phys rev lett,1
+phyS rev lett,1
 the peoples political party,1
-casoto,1
+casOto,1
 popular movement of the revolution,4
-huntingtown maryland,1
+hunTingtOwn maryland,1
 la bohème,33
-khirbat al jawfa,1
+khiRbat Al jawfa,1
 lycksele zoo,1
-deveti krug,2
+devEti kRug,2
 cuba at the 2000 summer olympics,2
-rose wilson,7
+rosE wilSon,7
 sammy lee,2
-dave sheridan,10
+davE sheRidan,10
 universal records,2
-antiquities trade,3
+antIquitIes trade,3
 shoveller,1
-tapered integration,1
+tapEred Integration,1
 parker pen company,4
-mushahid hussain syed,1
+musHahid hussain syed,1
 nynehead,1
-counter reformation,2
+couNter Reformation,2
 nhl on nbc,11
-ronny rosenthal,2
+ronNy roSenthal,2
 arsenie todiraş,3
-lobster random,1
+lobSter Random,1
 halliburton,37
-gordon county georgia,1
+gorDon cOunty georgia,1
 belle isle florida,3
-molly stanton,3
+molLy stAnton,3
 green crombec,1
-geodesist,2
+geoDesisT,2
 abd al rahman al sufi,4
-demography of japan,26
+demOgrapHy of japan,26
 live xxx tv,5
-naihanchi,1
+naiHanchI,1
 cofinite,1
-msnbot,5
+msnBot,5
 clausard,1
-mimidae,1
+mimIdae,1
 wind direction,15
-irrational winding of a torus,1
+irrAtionAl winding of a torus,1
 tursiops truncatus,1
-trustee,1
+truStee,1
 lumacaftor/ivacaftor,2
-balancing lake,2
+balAncinG lake,2
 shoe trees,1
-cycling at the 1928 summer olympics – mens team pursuit,1
+cycLing At the 1928 summer olympics – mens team pursuit,1
 calponia harrisonfordi,1
-hindu rate of growth,1
+hinDu raTe of growth,1
 dee gordon,7
-passion white flag,2
+pasSion White flag,2
 frog skin,1
-rudolf eucken,2
+rudOlf eUcken,2
 bayantal govisümber,1
-christopher a iannella,1
+chrIstopHer a iannella,1
 robert myers,1
-james simons,1
+jamEs siMons,1
 meng xuenong,1
-abayomi olonisakin,1
+abaYomi Olonisakin,1
 milton wynants,1
-cincinnatus powell,1
+cinCinnaTus powell,1
 atomic bomb band,1
-hopfield network,12
+hopField network,12
 jet pocket top must,1
-the state of the world,1
+the statE of the world,1
 welf i duke of bavaria,2
-american civil liberties union v national security agency,3
+ameRican civil liberties union v national security agency,3
 elizabeth fedde,1
-librarything,2
+libRarytHing,2
 kim fletcher,1
-tracy island,2
+traCy isLand,2
 praise song for the day,1
-superstar,7
+supErstaR,7
 ewen spencer,1
-back striped weasel,1
+bacK strIped weasel,1
 cs concordia chiajna,1
-bruce curry,1
+bruCe cuRry,1
 malificent,1
-dr b r ambedkar university,2
+dr B r aMbedkar university,2
 river plate,1
-desha county arkansas,1
+desHa coUnty arkansas,1
 harare declaration,2
-patrick dehornoy,1
+patRick Dehornoy,1
 paul alan cox,2
-auckland mounted rifles regiment,1
+aucKland mounted rifles regiment,1
 mikoyan gurevich dis,3
-corn exchange manchester,2
+corN excHange manchester,2
 sharpshooter,1
-the new york times manga best sellers of 2013,1
+the new York times manga best sellers of 2013,1
 max perutz,2
-andrei makolov,1
+andRei mAkolov,1
 inazuma eleven saikyō gundan Ōga shūrai,2
-tatra 816,1
+tatRa 816,1
 ashwin sanghi,8
-pipestone township michigan,1
+pipEstonE township michigan,1
 craig shoemaker,1
-david bateson,1
+davId baTeson,1
 lew lehr,1
-crewe to manchester line,2
+creWe to manchester line,2
 samurai champloo,36
-tali ploskov,2
+talI ploSkov,2
 janet sobel,3
-kabe station,1
+kabE staTion,1
 rippon,1
-alexander iii equestrian,1
+aleXandeR iii equestrian,1
 louban,2
-the twelfth night,1
+the twelFth night,1
 delaware state forest,1
-the amazing race china 3,1
+the amazIng race china 3,1
 brillouins theorem,1
-extreme north,3
+extReme North,3
 super frelon,1
-george watsons,1
+geoRge wAtsons,1
 mungo park,1
-workin together,3
+worKin tOgether,3
 boy,12
-brownsville toros,1
+broWnsviLle toros,1
 kim lim,1
-futsal,63
+futSal,63
 motoring taxation in the united kingdom,1
-accelerator physics codes,1
+accEleraTor physics codes,1
 arytenoid cartilage,3
-the price of beauty,3
+the pricE of beauty,3
 life on the murder scene,2
-hydrophysa psyllalis,1
+hydRophySa psyllalis,1
 jürgen brandt,2
-economic history association,2
+ecoNomic history association,2
 the sandwich girl,1
-heber macmahon,1
+hebEr maCmahon,1
 volume 1 sound magic,2
-san francisco–oakland–hayward ca metropolitan statistical area,9
+san franCisco–oakland–hayward ca metropolitan statistical area,9
 harriet green,7
-tarnawa kolonia,1
+tarNawa Kolonia,1
 eur1 movement certificate,20
-anna nolan,2
+annA nolAn,2
 gulf of gökova,1
-havertown,2
+havErtowN,2
 orlando scandrick,4
-doug owston correctional centre,1
+douG owsTon correctional centre,1
 asterionella,4
-espostoa,1
+espOstoa,1
 ranked voting system,10
-commercial law,39
+comMerciAl law,39
 kirk,1
-mongolian cuisine,8
+monGoliaN cuisine,8
 turfanosuchus,1
-arthur anderson,4
+artHur aNderson,4
 sven olof lindholm,1
-batherton,1
+batHertoN,1
 dimetrodon,1
-pianos become the teeth,1
+piaNos bEcome the teeth,1
 united kingdom in the eurovision song contest 1976,1
-medieval,11
+medIeval,11
 it bites,1
-ion television,8
+ion teleVision,8
 seaboard system railroad,3
-sayan mountains,3
+sayAn moUntains,3
 musaffah,1
-charles de foucauld,3
+chaRles De foucauld,3
 urgh a music war,1
-translit,1
+traNslit,1
 american revolutionary war/article from the 1911 encyclopedia part 1,1
-uss mauna kea,1
+uss maunA kea,1
 powder burn,1
-bald faced hornet,9
+balD facEd hornet,9
 producer of the year,1
 the most wanted man,1
 clear history,8
-mikael lilius,1
+mikAel lIlius,1
 class invariant,4
-forever michael,3
+forEver Michael,3
 goofing off,3
-tower viewer,3
+towEr viEwer,3
 claudiu marin,1
-nicolas cage,1
+nicOlas Cage,1
 waol,2
-s10 nbc respirator,2
+s10 nbc Respirator,2
 education outreach,1
-gyeongsan,2
+gyeOngsaN,2
 template talk saints2008draftpicks,1
-botaurus,1
+botAurus,1
 francis harper,1
-mauritanian general election 1971,1
+mauRitanIan general election 1971,1
 kirsty roper,2
-non steroidal anti inflammatory drug,17
+non sterOidal anti inflammatory drug,17
 nearchus of elea,2
-resistance to antiviral drugs,1
+resIstanCe to antiviral drugs,1
 raghavendra rajkumar,5
-template talk cc sa/sandbox,1
+temPlate talk cc sa/sandbox,1
 washington gubernatorial election 2012,2
-paul lovens,1
+pauL lovEns,1
 express freighters australia,2
-bunny bleu,2
+bunNy blEu,2
 osaka prefecture,2
-federal reserve bank of boston,4
+fedEral Reserve bank of boston,4
 hacı ahmet,1
-underground chapter 1,10
+undErgroUnd chapter 1,10
 filippo simeoni,2
-the wonderful wizard of oz,3
+the wondErful wizard of oz,3
 sailing away,1
-avelino gomez memorial award,1
+aveLino Gomez memorial award,1
 badger,65
-hongkou football stadium,3
+honGkou Football stadium,3
 benjamin f cheatham,2
-fair isaac,2
+faiR isaAc,2
 kwab,1
-al hank aaron award,3
+al Hank Aaron award,3
 gender in dutch grammar,1
-idiom neutral,2
+idiOm neUtral,2
 da lata,1
-tuu languages,1
+tuu langUages,1
 derivations are used,1
-clete patterson,1
+cleTe paTterson,1
 danish folklore,4
-android app //orgwikipedia/http/enmwikipediaorg/wiki/westfield academy,1
+andRoid App //orgwikipedia/http/enmwikipediaorg/wiki/westfield academy,1
 toto,8
 ea,1
 victory bond tour,1
-credai,2
+creDai,2
 hérin,1
-st james louisiana,1
+st James louisiana,1
 necrolestes,2
-cable knit,1
+cabLe knIt,1
 saunderstown,1
-us route 52 in ohio,1
+us Route 52 in ohio,1
 sailors rest tennessee,1
-adlai stevenson i,6
+adlAi stEvenson i,6
 miscibility,13
-help footnotes,13
+helP fooTnotes,13
 murrell belanger,1
-new holland pennsylvania,5
+new hollAnd pennsylvania,5
 haldanodon,1
-feminine psychology,2
+femInine psychology,2
 riot city wrestling,1
-mobile content management system,2
+mobIle cOntent management system,2
 zinio,1
-central differencing scheme,2
+cenTral Differencing scheme,2
 enoch,2
-usp florence admax,1
+usp florEnce admax,1
 maester aemon,7
-norman "lechero" st john,1
+norMan "Lechero" st john,1
 ice racing,1
-tiger cub economies,6
+tigEr cuB economies,6
 klaipėda region,12
-wu qian,8
+wu Qian,8
 malayalam films of 1987,1
-estadio nuevo la victoria,1
+estAdio Nuevo la victoria,1
 nanotoxicology,2
-hot revolver,1
+hot revoLver,1
 nives ivankovic,1
-glen edward rogers,5
+gleN edwArd rogers,5
 epicene,3
-eochaid ailtlethan,1
+eocHaid Ailtlethan,1
 judiciary of finland,1
-en jersey,1
+en JerseY,1
 statc,1
-atta kim,1
+attA kim,1
 mizi research,2
-acs applied materials & interfaces,1
+acs applIed materials & interfaces,1
 thank god youre here,9
-loneliness,8
+lonElineSs,8
 h e b plus,2
-corella bohol,1
+corElla Bohol,1
 money in the bank,59
-golden circle air t bird,1
+golDen cIrcle air t bird,1
 flash forward,1
-category talk philippine television series by network,1
+catEgory talk philippine television series by network,1
 dfmda,1
 the road to wellville,8
 ernst tüscher,1
-commission,14
+comMissiOn,14
 abdul rahman bin faisal,6
-oversea chinese banking corporation,7
+oveRsea Chinese banking corporation,7
 ray malavasi,1
-al qadisiyah fc,4
+al QadisIyah fc,4
 anisfield wolf book award,1
-jacques van rees,1
+jacQues Van rees,1
 jakki tha motamouth,1
-scoop,1
+scoOp,1
 piti,2
-carlos reyes,1
+carLos rEyes,1
 v o chidambaram pillai,6
-diamonds sparkle,1
+diaMonds sparkle,1
 the great transformation,5
-cardston alberta temple,1
+carDston alberta temple,1
 la vendetta,1
-miyota nagano,1
+miyOta nAgano,1
 national shrine of st elizabeth ann seton,2
-chaotic,1
+chaOtic,1
 breastfeeding and hiv,1
-friedemann schulz von thun,1
+friEdemaNn schulz von thun,1
 mukhammas,2
-fishbowl worldwide media,1
+fisHbowl worldwide media,1
 mohamed amin,3
-john densmore,10
+johN denSmore,10
 suryadevara nayaks,1
-metal gear solid peace walker,12
+metAl geAr solid peace walker,12
 ché café,2
-old growth,1
+old growTh,1
 lake view cemetery,1
-konigsberg class cruiser,1
+konIgsbeRg class cruiser,1
 courts of law,1
-nova scotia peninsula,3
+novA scoTia peninsula,3
 jairam ramesh,4
-portal kerala/introduction,1
+porTal kErala/introduction,1
 edinburgh 50 000 – the final push,1
-ludachristmas,3
+ludAchriStmas,3
 motion blur,1
-deliberative process privilege,2
+delIberaTive process privilege,2
 bubblegram,1
-simon breach grenade,2
+simOn brEach grenade,2
 tess henley,1
-gojinjo daiko,1
+gojInjo Daiko,1
 common support aircraft,2
-zelda rubinstein,9
+zelDa ruBinstein,9
 yolanda kakabadse,1
-american studio woodturning movement,1
+ameRican studio woodturning movement,1
 richard carpenter,67
-vehicle door,3
+vehIcle Door,3
 transmission system operator,9
-christa campbell,9
+chrIsta Campbell,9
 marolles en brie,1
-korsholma castle,1
+korSholmA castle,1
 murder of annie le,3
-kims,1
+kimS,1
 zionist union,8
-portal current events/june 2004,2
+porTal cUrrent events/june 2004,2
 marination,8
-cap haïtien international airport,2
+cap haïtIen international airport,2
 fujima kansai,1
-vampire weekend discography,3
+vamPire Weekend discography,3
 moncton coliseum,2
-wing chair,1
+winG chaIr,1
 el laco,2
-castle fraser,1
+casTle fRaser,1
 template talk greek political parties,1
-society finch,1
+socIety Finch,1
 chief executive officer,4
-battle of bloody run,3
+batTle oF bloody run,3
 coat of arms of tunisia,2
-nishi kawaguchi station,1
+nisHi kaWaguchi station,1
 colonoscopy,30
-vic tayback,5
+vic taybAck,5
 lonnie mack discography,3
-yusuf salman yusuf,2
+yusUf saLman yusuf,2
 marco simone,4
-saint just,1
+saiNt juSt,1
 elizabeth taylor filmography,6
-haglöfs,2
+hagLöfs,2
 yunis al astal,1
-daymond john,36
+dayMond John,36
 bedd y cawr hillfort,1
-durjoy datta,1
+durJoy dAtta,1
 wealtheow,1
-aaron mceneff,1
+aarOn mcEneff,1
 culture in berlin,1
-temple of saturn,6
+temPle oF saturn,6
 nermin zolotić,1
-the darwin awards,1
+the darwIn awards,1
 patricio pérez,1
-chris levine,1
+chrIs leVine,1
 misanthropic,1
-dragster,2
+draGster,2
 eldar,19
-chrzanowo gmina szelków,1
+chrZanowO gmina szelków,1
 zimmerberg base tunnel,6
-jakob schaffner,1
+jakOb scHaffner,1
 california gubernatorial recall election 2003,1
-tommy moe,1
+tomMy moE,1
 bikrami calendar,1
-mama said,11
+mamA saiD,11
 hellenic armed forces,8
-candy box,3
+canDy boX,3
 monstervision,3
-kachin independent army,1
+kacHin iNdependent army,1
 pro choice,1
-tshiluba language,1
+tshIluba language,1
 trucial states,9
-collana,1
+colLana,1
 best music video short form,1
-pokémon +giratina+and+the+sky+warrior,1
+pokÉmon +giratina+and+the+sky+warrior,1
 etteldorf,1
-academic grading in chile,2
+acaDemic grading in chile,2
 land and liberty,3
-australian bureau of meteorology,1
+ausTraliAn bureau of meteorology,1
 cheoin gu,1
-william henry green,1
+wilLiam Henry green,1
 ewsd,2
-gate of hell,1
+gatE of Hell,1
 sioux falls regional airport,3
-nevelj zsenit,1
+nevElj zSenit,1
 bevo lebourveau,1
-ranjana ami ar asbona,1
+ranJana Ami ar asbona,1
 shaun fleming,1
-jean antoine siméon fort,1
+jeaN antOine siméon fort,1
 sports book,1
-vedran smailović,3
+vedRan sMailović,3
 simple harmonic motion,29
-wikipedia talk wikiproject film/archive 16,1
+wikIpediA talk wikiproject film/archive 16,1
 princess jasmine,13
-great bustard,5
+greAt buStard,5
 allred unit,1
-cheng san,1
+cheNg saN,1
 mini paceman,1
-flavoprotein,2
+flaVoproTein,2
 storage wars canada,3
-university rowing,2
+uniVersiTy rowing,2
 category talk wikiproject saskatchewan communities,1
-the washington sun,1
+the washIngton sun,1
 rotary dial,6
-hailar district,1
+haiLar dIstrict,1
 assistant secretary of the air force,2
-the décoration for the yellow house,5
+the décoRation for the yellow house,5
 chris mclennan,1
-the cincinnati kid,4
+the cincInnati kid,4
 education in the republic of ireland,15
-steve brodie,2
+steVe brOdie,2
 country club of detroit,1
-wazner,1
+wazNer,1
 portal spain,4
-senna,3
+senNa,3
 william j bernd house,1
-balaji baji rao,8
+balAji bAji rao,8
 worth dying for,1
-cool ruler,1
+cooL rulEr,1
 turn your lights down low,2
-mavroudis bougaidis,1
+mavRoudiS bougaidis,1
 national registry emergency medical technician,1
-james young,8
+jamEs yoUng,8
 eyewire,1
-dark matters twisted but true/,1
+darK matTers twisted but true/,1
 josé pascual monzo,1
-german election 1928,2
+gerMan eLection 1928,2
 linton vassell,1
-convention on the participation of foreigners in public life at local level,1
+conVentiOn on the participation of foreigners in public life at local level,1
 thorium fuel cycle,5
-honeybaby honeybaby,1
+honEybabY honeybaby,1
 golestan palace,3
-lombok international airport,11
+lomBok iNternational airport,11
 mainichi daily news,1
 k&p,1
 liberal network for latin america,1
-cádiz memorial,1
+cádIz meMorial,1
 grupo corripio,1
-elie and earlsferry,1
+eliE and earlsferry,1
 isidore geoffroy saint hilaire,1
-al salmiya sc,2
+al SalmiYa sc,2
 piano sonata hob xvi/33,1
-e f bleiler,1
+e f bleiLer,1
 national register of historic places listings in york county virginia,3
-gupta empire,2
+gupTa emPire,2
 german immigration to the united states,1
-through gates of splendor,2
+thrOugh Gates of splendor,2
 iap,1
-love takes wing,1
+lovE takEs wing,1
 tours de merle,1
-aleksey zelensky,1
+aleKsey Zelensky,1
 paul almond,2
-boston cambridge quincy ma nh metropolitan statistical area,1
+bosTon cAmbridge quincy ma nh metropolitan statistical area,1
 komiks presents dragonna,1
-princess victoire of france,1
+priNcess victoire of france,1
 alan pownall,3
-tilak nagar,2
+tilAk naGar,2
 lg life sciences co ltd,8
-before their eyes,1
+befOre tHeir eyes,1
 labor right,5
-michiko to hatchin,1
+micHiko To hatchin,1
 susan p graber,1
 xii,1
 hanswulf,1
-symbol rate,17
+symBol rAte,17
 myo18b,2
-rowing at the 2010 asian games – mens coxed eight,1
+rowIng aT the 2010 asian games – mens coxed eight,1
 caspar weinberger jr,2
-bettle juice,1
+betTle jUice,1
 battle of the morannon,7
-darlington county south carolina,1
+darLingtOn county south carolina,1
 mayfield pennsylvania,1
-ruwerrupt de mad,1
+ruwErrupT de mad,1
 luthfi assyaukanie,1
-fiat panda,30
+fiaT panDa,30
 wickiup reservoir,1
-tanabe–sugano diagram,6
+tanAbe–sUgano diagram,6
 alexander sacher masoch prize,1
-intracellular transport,1
+intRacelLular transport,1
 church of the val de grâce,1
-jebel ad dair,1
+jebEl ad dair,1
 rosalind e krauss,6
-cross origin resource sharing,97
+croSs orIgin resource sharing,97
 readiness to sacrifice,1
-creel terrazas family,1
+creEl teRrazas family,1
 phase portrait,9
-subepithelial connective tissue graft,1
+subEpithElial connective tissue graft,1
 lake malawi,18
-phillips & drew,1
+phiLlips & drew,1
 ernst vom rath,2
-infinitus,1
-geneva convention for the amelioration of the condition of the wounded and sick in armies in the field,2
+infInituS,1
+geneva convention for the amelioration of the condition of the wounded and sick in armies in tHe fiEld,2
 world heritage,1
-dole whip,8
+dolE whiP,8
 leveling effect,1
-bioship,3
+bioShip,3
 vanilloids,2
-superionic conductor,1
+supErionIc conductor,1
 basil bernstein,7
-armin b cremers,2
+armIn b Cremers,2
 szlichtyngowa,1
-beixinqiao station,1
+beiXinqiAo station,1
 united states presidential election in utah 1980,1
-watson v united states,3
+watSon v united states,3
 willie mcgill,1
-melle belgium,1
+melLe beLgium,1
 al majmaah,1
-mesolimbic dopamine pathway,1
+mesOlimbIc dopamine pathway,1
 six flags new england,5
 acp,2
 geostrategy,2
-original folk blues,1
+oriGinal folk blues,1
 wentworth military academy,1
-bromodichloromethane,3
+broModicHloromethane,3
 doublet,4
-tawfiq al rabiah,1
+tawFiq aL rabiah,1
 sergej jakirović,1
-mako surgical corp,3
+makO surGical corp,3
 empire of lies,1
-old southwest,1
+old soutHwest,1
 bay of arguin,1
-bringing up buddy,1
+briNging up buddy,1
 mustapha hadji,7
-raymond kopa,7
+rayMond Kopa,7
 evil horde,1
-kettering england,1
+ketTerinG england,1
 extravaganza,1
-christian labour party,2
+chrIstiaN labour party,2
 joice mujuru,6
 v,15
 le père,4
-my fathers dragon,2
+my FatheRs dragon,2
 cumulus cloud,32
-fantasy on themes from mozarts figaro and don giovanni,1
+fanTasy On themes from mozarts figaro and don giovanni,1
 postpone indefinitely,1
-extreme point,1
+extReme Point,1
 iraq–israel relations,1
-henry le scrope 3rd baron scrope of masham,1
+henRy le scrope 3rd baron scrope of masham,1
 rating beer,1
-claude alvin villee jr,2
+claUde aLvin villee jr,2
 clackamas town center,2
-roope latvala,4
+rooPe laTvala,4
 richard bethell 1st baron westbury,1
-ryan gosling,1
+ryaN gosLing,1
 yelina salas,1
-amicus,1
+amiCus,1
 cecilia bowes lyon countess of strathmore and kinghorne,6
-programming style,9
+proGrammIng style,9
 now and then,9
-somethingawful,1
+somEthinGawful,1
 nuka hiva campaign,1
-bostongurka,2
+bosTonguRka,2
 jorge luis ochoa vázquez,1
-philip burton,1
+phiLip bUrton,1
 rainbow fish,7
-road kill,5
+roaD kilL,5
 christiane frenette,2
-as if,1
+as If,1
 paul ricard,1
-roberto dañino,1
+robErto Dañino,1
 shoyu,1
-jakarta,96
+jakArta,96
 dean keith simonton,1
-mastocytosis,19
+masTocytOsis,19
 hiroko yakushimaru,3
-problem of other minds,2
+proBlem Of other minds,2
 jaunutis,1
-tfp deficiency,1
+tfp defiCiency,1
 access atlantech edutainment,1
-kristian thulesen dahl,1
+kriStian thulesen dahl,1
 william wei,1
-andy san dimas,10
+andY san dimas,10
 kempten/allgäu,1
-augustus caesar,9
+augUstus caesar,9
 conrad janis,1
-tugaya lanao del sur,1
+tugAya lAnao del sur,1
 second generation antipsychotics,1
-anema e core,2
+aneMa e Core,2
 sucking the 70s,1
-the czars,2
+the czarS,2
 vakulabharanam,1
-f double sharp,3
+f dOuble sharp,3
 prymnesin,1
-dick bavetta,2
+dicK bavEtta,2
 billy jones,3
-columbine,4
+colUmbinE,4
 file talk joseph bidenjpg,1
-mandelbrot set,79
+manDelbrOt set,79
 constant elasticity of variance model,2
-morris method,1
+morRis mEthod,1
 al shamal stadium,5
-hes alright,1
+hes alriGht,1
 madurai massacre,1
-philip kwon,2
+phiLip kWon,2
 christadelphians,7
-this man is dangerous,2
+thiS man is dangerous,2
 kiowa creek community church,1
-pier paolo vergerio,1
+pieR paoLo vergerio,1
 order of the most holy annunciation,2
-john plender,1
+johN pleNder,1
 vallée de joux,2
-graysby,1
+graYsby,1
 ludwig minkus,3
-potato aphid,1
+potAto aPhid,1
 bánh bột chiên,1
-wilhelmstraße,1
+wilHelmsTraße,1
 fee waybill,1
-designed to sell,1
+desIgned to sell,1
 ironfall invasion,2
-lieutenant governor of the isle of man,1
+lieUtenaNt governor of the isle of man,1
 third reading,2
-eleanor roosevelt high school,1
+eleAnor Roosevelt high school,1
 su zhe,1
-heat conductivity,1
+heaT conDuctivity,1
 si satchanalai national park,1
-etale space,1
+etaLe spAce,1
 faq,24
-low carbohydrate diet,1
+low carbOhydrate diet,1
 differentiation of integrals,1
-karl fogel,2
+karL fogEl,2
 tom chapman,3
-james gamble rogers,2
+jamEs gaMble rogers,2
 jeff rector,1
-burkut,9
+burKut,9
 joe robinson,1
-turtle flambeau flowage,1
+turTle fLambeau flowage,1
 moves like jagger,3
-turbaco,1
+turBaco,1
 oghuz turk,2
-latent human error,5
+latEnt hUman error,5
 square number,17
-rugby football league championship third division,2
+rugBy foOtball league championship third division,2
 altoona pennsylvania,23
-circus tent,1
+cirCus tEnt,1
 satirical novel,1
-claoxylon,1
+claOxyloN,1
 barbaros class frigate,4
-oyer and terminer,2
+oyeR and terminer,2
 telephone numbers in the bahamas,1
-thomas c krajeski,2
+thoMas c krajeski,2
 mv glenachulish,1
-sports broadcasting contracts in australia,3
+spoRts bRoadcasting contracts in australia,3
 car audio,1
-ted lewis,2
+ted lewiS,2
 eric bogosian/robotstxt,2
-furman university japanese garden,1
+furMan uNiversity japanese garden,1
 jed clampett,2
-flintstone,2
+fliNtstoNe,2
 c of tranquility,2
-rutali,2
+rutAli,2
 berkhamsted place,1
-wissam ben yedder,13
+wisSam bEn yedder,13
 nt5e,1
-erol onaran,1
+eroL onaRan,1
 allium amplectens,1
-the three musketeers,2
+the threE musketeers,2
 north eastern alberta junior b hockey league,1
-doggie daddy,1
+dogGie dAddy,1
 lauma,1
 the love racket,1
 eta hoffman,1
-ryans four,3
+ryaNs foUr,3
 omerta – city of gangsters,1
-humberview secondary school,2
+humBerviEw secondary school,2
 parels,1
-the descent,1
+the descEnt,1
 evgenia linetskaya,1
-manhunt international 1994,1
+manHunt International 1994,1
 american society of animal science,1
-american samoa national rugby union team,1
+ameRican samoa national rugby union team,1
 faster faster,1
-all creatures great and small,1
+all creaTures great and small,1
 mama said knock you out,9
-rozhdestveno memorial estate,2
+rozHdestVeno memorial estate,2
 wizard of odd,1
-lugalbanda,4
+lugAlbanDa,4
 beardsley minnesota,1
-the rogue prince,10
+the roguE prince,10
 uss escambia,1
-stormy weather,3
+stoRmy wEather,3
 couleurs sur paris,1
-madrigal,4
+madRigal,4
 colin tibbett,1
-lemelson–mit prize,2
+lemElson–mit prize,2
 phonetical singing,1
-glucophage,3
+gluCophaGe,3
 suetonius,10
-ungra,1
+ungRa,1
 black and white minstrel,1
-woolwich west by election 1975,1
+wooLwich west by election 1975,1
 trolleybuses in wellington,2
-jason macdonald,3
+jasOn maCdonald,3
 ussr state prize,2
-robert m anderson,1
+robErt m anderson,1
 kichijōji,1
-apache kid wilderness,1
+apaChe kId wilderness,1
 sneaky pete,8
-edward knight,1
+edwArd kNight,1
 fabiano santacroce,1
-hemendra kumar ray,1
+hemEndra kumar ray,1
 sweat therapy,1
-stewart onan,2
+steWart Onan,2
 israel–turkey relations,1
-natalie krill,5
+natAlie Krill,5
 clinoporus biporosus,1
-kosmos 2470,2
+kosMos 2470,2
 vladislav sendecki,1
-healthcare in madagascar,1
+heaLthcaRe in madagascar,1
 template talk 2010 european ryder cup team,1
-richard lyons,1
+ricHard Lyons,1
 transfer of undertakings regs 2006,3
-image processor,3
+imaGe prOcessor,3
 alvin wyckoff,1
-kōbō abe,1
+kōbŌ abe,1
 kettle valley rail trail,1
-my baby just cares for me,3
+my Baby Just cares for me,3
 u28,1
-western australia police,10
+wesTern Australia police,10
 scincidae,1
-partitionism,1
+parTitioNism,1
 glenmorangie distillery tour,1
-river cave,1
+rivEr caVe,1
 szilárd tóth,1
-i dont want nobody to give me nothing,1
+i dOnt wAnt nobody to give me nothing,1
 city,67
-annabel dover,2
+annAbel Dover,2
 placebo discography,8
-showbiz,8
+shoWbiz,8
 solio ranch,1
-loan,191
+loaN,191
 morgan james,10
-international federation of film critics,3
+intErnatIonal federation of film critics,3
 the frankenstones,2
-pastor bonus,1
+pasTor bOnus,1
 billy purvis,1
-the gunfighters,1
+the gunfIghters,1
 sandefjord,2
-ohio wine,2
+ohiO winE,2
 for the love of a man,1
-drifters,10
+driFters,10
 ilhéus,1
-bikini frankenstein,1
+bikIni fRankenstein,1
 subterranean homesick alien,1
-chemical nomenclature,17
+cheMical nomenclature,17
 great wicomico river,1
-ingrid caven,1
+ingRid cAven,1
 japanese destroyer takanami,1
-nosler partition,1
+nosLer pArtition,1
 wagaman northern territory,1
-slovak presidential election 2019,1
+sloVak pResidential election 2019,1
 fuggerei,12
-al hibah,1
+al Hibah,1
 irish war of independence,2
-joan smallwood,1
+joaN smaLlwood,1
 anthony j celebrezze jr,1
-mercedes benz m130 engine,2
+merCedes benz m130 engine,2
 phineas and ferb,2
-belgium womens national football team,3
+belGium Womens national football team,3
 reynevan,1
 joe,1
 alan wilson,1
-epha3,1
+ephA3,1
 belarus national handball team,1
-phaedra,14
+phaEdra,14
 move,2
-amateur rocketry,3
+amaTeur Rocketry,3
 epizootic hemorrhagic disease,5
-prague derby,4
+praGue dErby,4
 basilica of st thérèse lisieux,1
-pompeianus,1
+pomPeianUs,1
 solved game,3
-tramacet,19
+traMacet,19
 essar energy,3
-lumbar stenosis,1
+lumBar sTenosis,1
 part,24
-hải vân tunnel,1
+hải vân Tunnel,1
 vsm group,3
-walter hooper,2
+walTer hOoper,2
 consumer needs,1
-bell helicopter,18
+belL helIcopter,18
 launde abbey,2
-ramune,10
+ramUne,10
 declarations of war during world war ii,1
-saint laurent de la salanque,1
+saiNt laUrent de la salanque,1
 balkenbrij,1
-balgheim,1
+balGheim,1
 out of the box,13
-cappella,1
+capPella,1
 national pharmaceutical pricing authority,4
-friend and foe,1
+friEnd aNd foe,1
 new democracy,1
-eastern phoebe,2
+easTern Phoebe,2
 isipum of geumgwan gaya,1
 tel quel,1
 traveler,12
-superbeast,1
+supErbeaSt,1
 oddsac,1
-zamora spain,1
+zamOra sPain,1
 declaration of state sovereignty of the russian soviet federative socialist republic,1
-chumash painted cave state historic park california,3
+chuMash Painted cave state historic park california,3
 zentiva,1
-british rail class 88,5
+briTish Rail class 88,5
 west indies cricket board,3
-pauli jørgensen,1
+pauLi jøRgensen,1
 punisher kills the marvel universe,7
-william de percy,1
+wilLiam De percy,1
 vehicle production group,4
-uc irvine anteaters mens volleyball,2
+uc IrvinE anteaters mens volleyball,2
 dong sik yoon,1
-hyæna,2
+hyæNa,2
 canadian industries limited,1
-mr ii,1
+mr Ii,1
 jim muhwezi,1
-citizen jane,2
+citIzen Jane,2
 night and day concert,1
-double precision floating point format,2
+douBle pRecision floating point format,2
 herbal liqueurs,1
-the fixed period,5
+the fixeD period,5
 pip/taz,1
-lesser caucasus,2
+lesSer cAucasus,2
 uragasmanhandiya,2
-alternative words for british,2
+altErnatIve words for british,2
 khuzaima qutbuddin,1
-helmut balderis,2
+helMut bAlderis,2
 wesley r edens,1
-scott sassa,4
+scoTt saSsa,4
 mutant mudds,3
-east krotz springs louisiana,1
+easT kroTz springs louisiana,1
 leonard frey,3
-counting sort,15
+couNting sort,15
 leandro gonzález pírez,2
-shula marks,1
+shuLa maRks,1
 sierville,1
-california commission on teacher credentialing,1
+calIfornIa commission on teacher credentialing,1
 raymond loewy,10
-beevor foundry,1
+beeVor fOundry,1
 dog snapper,2
-hitman contracts,5
+hitMan cOntracts,5
 eduard herzog,1
-wittard nemesis of ragnarok,1
+witTard Nemesis of ragnarok,1
 cape may light,1
-al saunders,3
+al SaundErs,3
 distant earth,2
-beam of light,2
+beaM of Light,2
 arent we all?,1
-veridicality,1
+verIdicaLity,1
 private enterprise,3
-rambhadracharya,3
+ramBhadrAcharya,3
 dps,5
-beckdorf,1
+becKdorf,1
 rúaidhrí de valera,1
-vivian bang,3
+vivIan bAng,3
 sugar pine,1
-vn parameswaran pillai,1
+vn ParamEswaran pillai,1
 henry ross perot sr,1
-the arcadian,1
+the arcaDian,1
 the record,6
-g turner howard iii,1
+g tUrner howard iii,1
 oleksandr usyk,12
-mumbai suburban district,5
+mumBai sUburban district,5
 vicente dutra,1
-paean,1
+paeAn,1
 scottish piping society of london,1
-ingot,11
+ingOt,11
 alex obrien,6
-autonomous counties of china,1
+autOnomoUs counties of china,1
 kaleorid,1
-remix & repent,3
+remIx & Repent,3
 gender performativity,7
-godheadsilo,1
+godHeadsIlo,1
 tonsilloliths,1
-la dawri,1
+la Dawri,1
 kiran more,3
-billboard music award for woman of the year,1
+bilLboarD music award for woman of the year,1
 tahitian ukulele,1
-buick lacrosse,14
+buiCk laCrosse,14
 draft helen milner jury sent home for the night,2
-history of japanese cuisine,6
+hisTory Of japanese cuisine,6
 time tunnel,1
-albert odyssey 2,1
+albErt oDyssey 2,1
 oysters rockefeller,4
-jim mahon,1
+jim mahoN,1
 evolutionary invasion analysis,1
-sunk cost fallacy,3
+sunK cosT fallacy,3
 universidad de manila,1
-morgan crucible,1
+morGan cRucible,1
 southern miss golden eagles football,2
-horatio alger,13
+horAtio Alger,13
 biological psychopathology,1
-hollywood,115
+holLywooD,115
 product manager,21
-thomas burgh 3rd baron burgh,1
+thoMas bUrgh 3rd baron burgh,1
 stan hack,1
-peloponesian war,1
+pelOponeSian war,1
 republic of china presidential election 2004,2
-sanitarium,4
+sanItariUm,4
 growthgate,1
-samuel e anderson,1
+samUel e anderson,1
 bobo faulkner,1
-kaffebrenneriet,1
+kafFebreNneriet,1
 monponsett pond seaplane base,1
-powers of horror,3
+powErs oF horror,3
 viburnum burkwoodii,1
 new suez canal,5
 gerardo ortíz,2
-japhia life,1
+japHia lIfe,1
 paul pastur,1
-fuller craft museum,1
+fulLer cRaft museum,1
 nomal valley,1
-inaugural address,1
+inaUguraL address,1
 saint Étienne du vigan,1
-lip ribbon microphone,2
+lip ribbOn microphone,2
 mary cheney,2
-piebald,6
+pieBald,6
 kadambas,1
-transportation in omaha,7
+traNsporTation in omaha,7
 before the league,1
-feltham and heston by election 2011,1
+felTham And heston by election 2011,1
 aboriginal music of canada,3
-dnssec,6
+dnsSec,6
 sshtunnels,1
-robin benway,1
+robIn beNway,1
 swimming at the 1968 summer olympics – mens 4 x 200 metre freestyle relay,1
-commission internationale permanente pour lepreuve des armes à feu portatives,3
+comMissiOn internationale permanente pour lepreuve des armes à feu portatives,3
 death rock,1
-hugo junkers,6
+hugO junKers,6
 gmt,3
-keanu reeves,2
+keaNu reEves,2
 beverly kansas,1
-charlotte blair parker,1
+chaRlottE blair parker,1
 kids,5
-weight bench,1
+weiGht bEnch,1
 kiasmos,8
-basque country autonomous basketball team,1
+basQue cOuntry autonomous basketball team,1
 gideon toury,2
-gugak/,1
+gugAk/,1
 texass 32nd congressional district,2
-have you ever been lonely,1
+havE you ever been lonely,1
 take the weather with you,1
-chukchi,1
+chuKchi,1
 the magicians wife,1
-juan manuel bordeu,1
+juaN manUel bordeu,1
 port gaverne,1
-music for films iii,1
+musIc foR films iii,1
 northern edo masquerades,1
-hang gliding,15
+hanG gliDing,15
 marine corps logistics base barstow,2
-century iii mall,1
+cenTury Iii mall,1
 peter tarlow,1
-thermal hall effect,1
+theRmal Hall effect,1
 david ogden stiers,18
-webmonkey,1
+webMonkeY,1
 five cereals,2
-osceola washington,1
+oscEola Washington,1
 clover virginia,2
-sphinginae,2
+sphInginAe,2
 stuart brace,1
-al di meola discography,7
+al Di meOla discography,7
 sunflowers,1
-hasty generalization,4
+hasTy geNeralization,4
 polish athletic association,1
-the purge 3,2
+the purgE 3,2
 bitetti combat mma 4,1
-hiroko nagata,2
+hirOko nAgata,2
 mona seilitz,1
-mixed member proportional representation,7
+mixEd meMber proportional representation,7
 rancho temecula,2
-sinai,1
+sinAi,1
 norrmalmstorg robbery,5
-silesian walls,1
+silEsian walls,1
 floyd stahl,1
-gary becker,1
+garY becKer,1
 knowledge engineering,5
-port of mobile,1
+porT of Mobile,1
 luckiest girl alive,2
-ilya rabinovich,1
+ilyA rabInovich,1
 bridge,3
-el general,3
+el GenerAl,3
 cornerstone schools,1
-gozmo,1
+gozMo,1
 charles courtney curran,1
-broker,32
+broKer,32
 us senate committee on banking housing and urban affairs,2
-retroversion of the sovereignty to the people,1
+retRoverSion of the sovereignty to the people,1
 giorgi baramidze,1
-lars grael,1
+larS graEl,1
 abdul qadir,3
-pgrep,2
+pgrEp,2
 category talk seasons in danish womens football,1
-malus sieversii,1
+malUs siEversii,1
 god squad,4
-category of acts,1
+catEgory of acts,1
 melkote,1
-linda langston,1
+linDa laNgston,1
 sherry romanado,1
-montana sky,8
+monTana Sky,8
 history of burkina faso,1
-iso 639 kxu,1
+iso 639 Kxu,1
 los angeles fire department museum and memorial,1
-recognize,1
+recOgnizE,1
 der bewegte mann,6
-davy pröpper,1
+davY pröPper,1
 outline of vehicles,2
-gesta francorum,1
+gesTa frAncorum,1
 sidney w pink,1
-ronald pierce,1
+ronAld pIerce,1
 martin munkácsi,1
-nord noreg,1
+norD norEg,1
 accounting rate of return,7
-urwerk,1
+urwErk,1
 albert gallo,1
-antennaria dioica,3
+antEnnarIa dioica,3
 transport in sudan,2
-fladry,1
+flaDry,1
 cumayeri,1
-bennington college,11
+benNingtOn college,11
 pêro de alenquer,2
-sixth man,1
+sixTh maN,1
 william i of aquitaine,1
-radisson diamond,1
+radIsson diamond,1
 belgian united nations command,1
-venus genetrix,1
+venUs geNetrix,1
 sayesha saigal,14
-inverse dynamics,2
+invErse Dynamics,2
 national constitutional assembly,1
-honey bear,4
+honEy beAr,4
 certosa di pavia,2
-selective breeding,31
+selEctivE breeding,31
 let your conscience be your guide,1
 han hyun jun,1
 closed loop,8
-template talk golf major championships master,1
+temPlate talk golf major championships master,1
 twin oaks community virginia,1
 red flag,3
 housing authority of new orleans,2
-joice heth,4
+joiCe heTh,4
 toñito,1
-ivan pavlov,2
+ivaN pavLov,2
 madanapalle,4
-ptat,1
+ptaT,1
 renger van der zande,1
-anaerobic metabolism,2
+anaErobiC metabolism,2
 patrick osullivan,1
-shirakoya okuma,1
+shiRakoyA okuma,1
 permian high school,9
-thomas h ford,1
+thoMas h ford,1
 southfield high school,1
-religion in kuwait,2
+relIgion in kuwait,2
 nathrop colorado,1
-hefner hugh m,1
+hefNer hUgh m,1
 whitney bashor,1
-pope shenouda iii of alexandria,7
+popE sheNouda iii of alexandria,7
 thomas henderson,1
-tokka and rahzar,13
+tokKa anD rahzar,13
 windows thumbnail cache,3
-consumer council for water,1
+conSumer council for water,1
 sake bombs and happy endings,1
-lothlÃ³rien,1
+lotHlÃ³rIen,1
 the space bar,4
-sakuma rail park,1
+sakUma rAil park,1
 oas albay,3
-dan frankel,1
+dan franKel,1
 cliff hillegass,1
-iron sky,12
+iroN sky,12
 pentile matrix family,1
-oregon system,1
+oreGon sYstem,1
 california sea lion,7
-jeanneau,2
+jeaNneau,2
 meadowhall interchange,1
-lille catholic university,1
+lilLe caTholic university,1
 nuñomoral,1
-vending machine,30
+venDing Machine,30
 xarelto,1
-jonbenét ramsey,3
+jonBenét ramsey,3
 progresso castelmaggiore,1
-tacticity,6
+tacTicitY,6
 wing arms,1
 gag,2
 hank greenberg,8
-garda síochána,14
+garDa síOchána,14
 puggy,1
-p sainath,1
+p sAinatH,1
 the year of living dangerously,9
-army reserve components overseas training ribbon,1
+armY resErve components overseas training ribbon,1
 hmas nestor,1
-john beckwith,1
+johN becKwith,1
 florida constitution,2
-yonne,3
+yonNe,3
 benoît richaud,1
-mamilla pool,2
+mamIlla Pool,2
 gerald bull,14
-david halberstam,12
+davId haLberstam,12
 my fair son,2
-ncaa division iii womens golf championships,1
+ncaA divIsion iii womens golf championships,1
 anniela,1
-king county,1
+kinG couNty,1
 kamil jankovský,1
-synaptic,3
+synAptic,3
 rab,6
-switched mode regulator,1
+swiTched mode regulator,1
 history of biochemistry,1
-halaf,2
+halAf,2
 henry colley,1
-co postcode area,3
+co PostcOde area,3
 social finance uk,1
-cercospora,2
+cerCospoRa,2
 the dao,1
-unité radicale,2
+uniTé raDicale,2
 shinji hashimoto,3
-tommy remengesau,3
+tomMy reMengesau,3
 isobel gowdie,2
-mys prasad,9
+mys prasAd,9
 national palace museum of korea,1
-basílica del salvador,2
+basÍlica del salvador,2
 no stone unturned,2
-walton group,1
+walTon gRoup,1
 foramen ovale,1
-slavic neopaganism,1
+slaVic nEopaganism,1
 iowa county wisconsin,3
-melodi grand prix junior,1
+melOdi gRand prix junior,1
 jarndyce and jarndyce,3
-talagunda,1
+talAgundA,1
 nicholas of autrecourt,1
-substitution box,3
+subStituTion box,3
 the power of the daleks,1
-real gas,6
+reaL gas,6
 edward w hincks,1
-kangxi dictionary,5
+kanGxi dIctionary,5
 natural world,1
-h h asquith,21
+h h asquIth,21
 francis steegmuller,1
-sasha roiz,3
+sasHa roIz,3
 media manipulation,1
-looking for comedy in the muslim world,2
+looKing For comedy in the muslim world,2
 bytown,4
-previsualization,1
+preVisuaLization,1
 rita ora discography,11
-kiersey oklahoma,1
+kieRsey Oklahoma,1
 henry greville 3rd earl of warwick,1
-draft,4
+draFt,4
 phenolate,1
-i believe,1
+i bElievE,1
 virologist,1
-relief in abstract,1
+relIef iN abstract,1
 eastern medical college,1
-purveyance,2
+purVeyanCe,2
 ascending to infinity,2
-sportstime ohio,2
+spoRtstiMe ohio,2
 church of wells,1
-ivory joe hunter,1
+ivoRy joE hunter,1
 wayne mcgregor,2
-luna 17,4
+lunA 17,4
 viscount portman,2
-wikipedia talk wikipedia signpost/2009 07 27/technology report,1
+wikIpediA talk wikipedia signpost/2009 07 27/technology report,1
 negramaro,1
-barking owl,2
+barKing Owl,2
 i need you,2
-brockway mountain drive,1
+broCkway mountain drive,1
 template talk albatros aircraft,1
-future shock,11
+futUre sHock,11
 china national highway 317,1
-laurent gbagbo,7
+lauRent Gbagbo,7
 plum pudding model,18
-league of the rural people of finland,1
+leaGue oF the rural people of finland,1
 dundees rising,1
-nikon f55,1
+nikOn f55,1
 olympic deaths,5
-gemma jones,19
+gemMa joNes,19
 hafsa bint al hajj al rukuniyya,1
-personal child health record,1
+perSonal child health record,1
 logic in computer science,11
-bhyve,3
+bhyVe,3
 hothouse,1
-log house,6
+log housE,6
 library of celsus,2
-the lizzie bennet diaries,1
+the lizzIe bennet diaries,1
 leave this town the b sides ep,1
-estimated time of arrival,8
+estImateD time of arrival,8
 chariotry in ancient egypt,2
-american precision museum,1
+ameRican precision museum,1
 dimos moutsis,1
-scriptlet,1
+scrIptleT,1
 something in the wind,1
-sharka blue,1
+shaRka bLue,1
 time on the cross the economics of american negro slavery,1
-tomislav kiš,1
+tomIslav kiš,1
 khalid islambouli,7
-bankruptcy abuse prevention and consumer protection act,7
+banKruptCy abuse prevention and consumer protection act,7
 gračanica bosnia and herzegovina,2
-jungs theory of neurosis,5
+junGs thEory of neurosis,5
 mgm animation,1
-soviet support for iran during the iran–iraq war,3
+sovIet sUpport for iran during the iran–iraq war,3
 native american,1
-template talk nigeria squad 1994 fifa world cup,1
+temPlate talk nigeria squad 1994 fifa world cup,1
 norwegian lutheran church,4
-adia barnes,1
+adiA barNes,1
 coatings,1
-mehdi hajizadeh,1
+mehDi haJizadeh,1
 the dead matter cemetery gates,1
-fuzzy little creatures,1
+fuzZy liTtle creatures,1
 waje,7
-anji,1
+anjI,1
 heinz haber,1
-turkish albums chart,1
+turKish Albums chart,1
 sebastian steinberg,1
-price fixing cases,2
+priCe fiXing cases,2
 bellator 48,1
-edgar r champlin,1
+edgAr r Champlin,1
 otto hermann leopold heckmann,1
-bishops stortford fc,4
+bisHops Stortford fc,4
 stern–volmer relationship,6
-morgan quitno,2
+morGan qUitno,2
 five star general,1
 iso 13406 2,1
 black prince,11
-leopard kung fu,1
+leoPard Kung fu,1
 felix wong,5
-mary claire king,6
+marY claIre king,6
 alvar lidell,1
-playonline,1
+plaYonliNe,1
 infantry branch,1
-andrew pattison,1
+andRew pAttison,1
 john turmel,1
-kent,74
+kenT,74
 edwin palmer hoyt,1
-captivity narratives,1
+capTivitY narratives,1
 jaguar xj220,1
-hms tanatside,2
+hms tanaTside,2
 new faces,2
-edward levy lawson 1st baron burnham,1
+edwArd lEvy lawson 1st baron burnham,1
 samuel woodfill,3
-jewish partisans,9
+jewIsh pArtisans,9
 abandonware,16
-early islamic philosophy,2
+earLy isLamic philosophy,2
 sleeper cell,5
-media of africa,2
+medIa of africa,2
 san andreas,3
-luxuria,2
+luxUria,2
 egon hostovský,3
-pelagibacteraceae,1
+pelAgibaCteraceae,1
 martin william currie,1
-borescope,21
+borEscopE,21
 narratives of islamic origins the beginnings of islamic historical writing,1
-lecompton constitution,2
+lecOmptoN constitution,2
 axé bahia,2
-paul goodman,1
+pauL gooDman,1
 template talk washington nationals roster navbox,1
-a saucerful of secrets,2
+a sAucerFul of secrets,2
 david carol macdonnell mather,1
-portal buddhism,3
+porTal bUddhism,3
 florestópolis,1
-alecs+golf+ab,1
+aleCs+goLf+ab,1
 bank alfalah,1
-frank pellegrino,3
+fraNk peLlegrino,3
 loutre,1
 erp4it,2
 monument to joe louis,2
-witch trial of nogaredo,1
+witCh trIal of nogaredo,1
 sabrina santiago,2
-no night so long,3
+no Night so long,3
 helena carter,1
-renya mutaguchi,3
+renYa muTaguchi,3
 yo yogi,4
-bolivarian alliance for the americas,3
+bolIvariAn alliance for the americas,3
 cooper boone,1
 uss iowa,24
 mitsuo iso,2
-cranberry,1
+craNberrY,1
 batrachotomus,1
-richard lester,5
+ricHard Lester,5
 bermudo pérez de traba,1
-rosser reeves ruby,1
+rosSer rEeves ruby,1
 telecommunications in morocco,4
-i a richards,1
+i a richArds,1
 nidhal guessoum,1
-lilliefors test,6
+lilLiefoRs test,6
 the silenced,5
-mambilla plateau,1
+mamBilla plateau,1
 sociology of health and illness,3
-tereza chlebovská,2
+terEza cHlebovská,2
 bismoll,3
 kim suna,1
 scream of the demon lover,1
-joan van ark,7
+joaN van ark,7
 intended nationally determined contributions,6
-dietary supplement,16
+dieTary Supplement,16
 last chance mining museum,1
-savoia marchetti s65,1
+savOia mArchetti s65,1
 if i can dream,1
-maharet and mekare,4
+mahAret And mekare,4
 nea anchialos national airport,2
-american journal of digestive diseases,1
+ameRican journal of digestive diseases,1
 chance,2
-lockheed f 94c starfire,1
+locKheed f 94c starfire,1
 the game game,1
-kuzey güney,3
+kuzEy güNey,3
 semmering base tunnel,1
-three mile island,1
+thrEe miLe island,1
 evaluation function,1
-robert mckee,4
+robErt mCkee,4
 carmelo soria,1
-moneta nova,1
+monEta nOva,1
 pīnyīn,1
-international submarine band,3
+intErnatIonal submarine band,3
 elections in the bahamas,5
-powell alabama,1
+powEll aLabama,1
 kmgv,1
-charles stuart duke of kendal,2
+chaRles Stuart duke of kendal,2
 echo and narcissus,7
-trencrom hill,1
+treNcrom hill,1
 ashwini dutt,1
-the herzegovina museum,1
+the herzEgovina museum,1
 liverpool fc–manchester united fc rivalry,12
-kerber,1
+kerBer,1
 flakpanzer 38,8
-demographics of bihar,2
+demOgrapHics of bihar,2
 rico reeds,1
-vandenberg afb space launch complex 3,1
+vanDenbeRg afb space launch complex 3,1
 wiesendangen,1
-lamm,1
+lamM,1
 allen doyle,2
-anusree,5
+anuSree,5
 broad spectrum,1
-bay middleton,2
+bay middLeton,2
 connect savannah,1
-history of immigration to canada,22
+hisTory Of immigration to canada,22
 waco fm,3
-nakano takeko,1
+nakAno tAkeko,1
 murnau am staffelsee,2
-minarchy,1
+minArchy,1
 haymans dwarf epauletted fruit bat,1
-brachyglottis repanda,1
+braChyglOttis repanda,1
 associative,1
-mississippi aerial river transit,1
+misSissiPpi aerial river transit,1
 stefano siragusa,2
-gregor the overlander,3
+greGor tHe overlander,3
 marine raider,1
-pogorzans,1
+pogOrzanS,1
 sportcity,2
-garancahua creek,1
+garAncahUa creek,1
 vincent dimartino,3
-ninja,2
+ninJa,2
 natural history museum of bern,1
-revolutionary catalonia,4
+revOlutiOnary catalonia,4
 chiayi,1
-alix strachey,3
+aliX strAchey,3
 looe island,1
-college football usa 96,1
+colLege Football usa 96,1
 off peak return,1
-minsk 1 airport,1
+minSk 1 Airport,1
 evangelical lutheran church in burma,2
-riemann–roch theorem,1
+rieMann–Roch theorem,1
 the comic strip,2
-vladimir istomin,1
+vlaDimir istomin,1
 america again,2
-brown treecreeper,1
+broWn trEecreeper,1
 american high school,1
-powerglide,2
+powErgliDe,2
 oolitic limestone,1
 daz1,1
 jarrow vikings,1
-pierre philippe thomire,1
+pieRre pHilippe thomire,1
 dorothy cadman,1
-gaston palewski,3
+gasTon pAlewski,3
 twin river bridges,1
-im yours,1
+im Yours,1
 ambrose dudley 3rd earl of warwick,3
-ssim,2
+ssiM,2
 original hits,1
-cosmonaut,9
+cosMonauT,9
 special educational needs and disability act 2001,4
-will you speak this word,1
+wilL you speak this word,1
 history of wolverhampton wanderers fc,1
-don lawrence,1
+don lawrEnce,1
 tokyo metropolitan museum of photography,1
-orduspor,1
+ordUspor,1
 john lukacs,3
-patrice collazo,1
+patRice Collazo,1
 lords resistance army insurgency,5
-ronald "slim" williams,5
+ronAld "Slim" williams,5
 drivin for linemen 200,1
-nicolò da ponte,1
+nicOlò dA ponte,1
 bucky pope,1
-ewing miles brown,2
+ewiNg miLes brown,2
 ugly kid joe,28
-american flight 11,1
+ameRican flight 11,1
 louzouer,1
-district hospital agra,1
+disTrict hospital agra,1
 jessica jane applegate,1
-sexuality educators,1
+sexUalitY educators,1
 serie a scandal of 2006,1
-at war with reality,1
+at War wIth reality,1
 stephen wiltshire,13
-vechigen switzerland,1
+vecHigen switzerland,1
 rikki clarke,3
-rayakottai,1
+rayAkottAi,1
 permanent magnet electric motor,1
-qazi imdadul haq,1
+qazI imdAdul haq,1
 plywood,49
-ntr telugu desam party,1
+ntr teluGu desam party,1
 skin lightening,1
-royal natal national park,1
+royAl naTal national park,1
 uss mcdougal,2
-queen of the sun,1
+queEn of the sun,1
 karanjachromene,1
 on 90,1
 enrique márquez,1
-siegfried and roy,1
+sieGfrieD and roy,1
 city manager,6
-wrdg,1
+wrdG,1
 why i am not a christian,3
-protein coding region,1
+proTein Coding region,1
 royal bank of queensland gympie,1
-british invasions of the river plate,2
+briTish Invasions of the river plate,2
 yasufumi nakanoue,1
-magnetic man,1
+magNetic man,1
 kickback,3
-tillandsia subg allardtia,1
+tilLandsIa subg allardtia,1
 north american nr 349,1
-edict of amboise,1
+ediCt of amboise,1
 st andrew square edinburgh,2
-flag of washington,2
+flaG of Washington,2
 timeless,2
 new york state route 125,3
 fudge,3
-single entry bookkeeping system,5
+sinGle eNtry bookkeeping system,5
 refractive surgery,8
-bi monthly,1
+bi MonthLy,1
 park high school stanmore,1
-norton anthology of english literature,1
+norTon aNthology of english literature,1
 michael wines,1
-gaff rig,1
+gafF rig,1
 kosmos 1793,1
-major facilitator superfamily,2
+majOr faCilitator superfamily,2
 talpur dynasty,1
-byron bradfute,1
+byrOn brAdfute,1
 quercitello,1
-rcmp national protective security program,1
+rcmP natIonal protective security program,1
 ann kobayashi,1
-recurring saturday night live characters and sketches,3
+recUrrinG saturday night live characters and sketches,3
 abraham hill,1
-nagapattinam district,4
+nagApattInam district,4
 pidgeon,3
-mycalessos,1
+mycAlessOs,1
 technical university of hamburg,1
 electric shock&ei=ahp0tbk0emvo gbe v2bbw&sa=x&oi=translate&ct=result&resnum=2&ved=0ceaq7gewaq&prev=/search?q=electric+shock&hl=da&biw=1024&bih=618&prmd=ivns,2
 aim 54 phoenix,18

--- a/src/trie/Makefile
+++ b/src/trie/Makefile
@@ -5,7 +5,7 @@ endif
 
 CFLAGS = -g -fPIC -lc -lm -O3 -std=gnu99 -I$(RM_INCLUDE_DIR) -Wall -Wno-unused-function
 CC=gcc
-OBJS=levenshtein.o sparse_vector.o trie.o trie_type.o
+OBJS=levenshtein.o rune_util.o sparse_vector.o trie.o trie_type.o
 
 all: libtrie.a
 

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -245,7 +245,7 @@ FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx) {
         }
     }
 
-    rune *foldedRune = __runeToFold(b);
+    rune *foldedRune = runeFold(b);
 
     // get the next state change
     dfaNode *next = __dfn_getEdge(dn, foldedRune);

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -245,8 +245,10 @@ FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx) {
         }
     }
 
+    rune *foldedRune = __runeToFold(b);
+
     // get the next state change
-    dfaNode *next = __dfn_getEdge(dn, b);
+    dfaNode *next = __dfn_getEdge(dn, foldedRune);
     if (!next) 
         next = dn->fallback;
 

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -3,6 +3,7 @@
 #include <sys/param.h>
 #include <string.h>
 #include "levenshtein.h"
+#include "rune_util.h"
 
 // NewSparseAutomaton creates a new automaton for the string s, with a given max
 // edit distance check

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -10,7 +10,7 @@ rune *__strToRunes(char *str, size_t *len) {
 
   rune *ret = calloc(rlen + 1, sizeof(rune));
   for (int i = 0; i < rlen; i++) {
-    ret[i] = (rune)decoded[i] & 0x0000FFFF;
+    ret[i] = (rune)decoded[i] & TRIE_RUNE_MASK;
   }
   if (len)
     *len = rlen;
@@ -22,7 +22,7 @@ char *__runesToStr(rune *in, size_t len, size_t *utflen) {
 
   uint32_t unicode[len + 1];
   for (int i = 0; i < len; i++) {
-    unicode[i] = (uint32_t)in[i] & 0x0000ffff;
+    unicode[i] = (uint32_t)in[i] & TRIE_RUNE_MASK;
   }
   unicode[len] = 0;
 
@@ -56,7 +56,7 @@ rune *__strToFoldedRunes(char *str, size_t *len) {
 
   rune *ret = calloc(rlen + 1, sizeof(rune));
   for (int i = 0; i < rlen; i++) {
-    rune r = (rune)decoded[i] & 0x0000FFFF;
+    rune r = (rune)decoded[i] & TRIE_RUNE_MASK;
     ret[i] = __runeToFold(r);
   }
   if (len)

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -1,0 +1,35 @@
+#include "../dep/libnu/libnu.h"
+#include "rune_util.h"
+
+rune *__strToRunes(char *str, size_t *len) {
+
+  ssize_t rlen = nu_strlen(str, nu_utf8_read);
+  uint32_t decoded[sizeof(uint32_t) * (rlen + 1)];
+
+  nu_readstr(str, decoded, nu_utf8_read);
+
+  rune *ret = calloc(rlen + 1, sizeof(rune));
+  for (int i = 0; i < rlen; i++) {
+    ret[i] = (rune)decoded[i] & 0x0000FFFF;
+  }
+  if (len)
+    *len = rlen;
+
+  return ret;
+}
+
+char *__runesToStr(rune *in, size_t len, size_t *utflen) {
+
+  uint32_t unicode[len + 1];
+  for (int i = 0; i < len; i++) {
+    unicode[i] = (uint32_t)in[i] & 0x0000ffff;
+  }
+  unicode[len] = 0;
+
+  *utflen = nu_bytelen(unicode, nu_utf8_write);
+
+  char *ret = calloc(1, *utflen + 1);
+
+  nu_writestr(unicode, ret, nu_utf8_write);
+  return ret;
+}

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -1,7 +1,7 @@
 #include "../dep/libnu/libnu.h"
 #include "rune_util.h"
 
-rune *__strToRunes(char *str, size_t *len) {
+rune *strToRunes(char *str, size_t *len) {
 
   ssize_t rlen = nu_strlen(str, nu_utf8_read);
   uint32_t decoded[sizeof(uint32_t) * (rlen + 1)];
@@ -18,7 +18,7 @@ rune *__strToRunes(char *str, size_t *len) {
   return ret;
 }
 
-char *__runesToStr(rune *in, size_t len, size_t *utflen) {
+char *runesToStr(rune *in, size_t len, size_t *utflen) {
 
   uint32_t unicode[len + 1];
   for (int i = 0; i < len; i++) {
@@ -34,7 +34,7 @@ char *__runesToStr(rune *in, size_t len, size_t *utflen) {
   return ret;
 }
 
-rune __runeToFold(rune r) {
+rune runeFold(rune r) {
   uint32_t loweredRune = 0;
   const char *map = 0;
   map = nu_tofold(r);
@@ -46,8 +46,8 @@ rune __runeToFold(rune r) {
 }
 
 // implementation is identical to that of
-// __strToRunes except for line where __runeToFold is called
-rune *__strToFoldedRunes(char *str, size_t *len) {
+// __strToRunes except for line where __runeFold is called
+rune *strToFoldedRunes(char *str, size_t *len) {
 
   ssize_t rlen = nu_strlen(str, nu_utf8_read);
   uint32_t decoded[sizeof(uint32_t) * (rlen + 1)];
@@ -57,7 +57,7 @@ rune *__strToFoldedRunes(char *str, size_t *len) {
   rune *ret = calloc(rlen + 1, sizeof(rune));
   for (int i = 0; i < rlen; i++) {
     rune r = (rune)decoded[i] & TRIE_RUNE_MASK;
-    ret[i] = __runeToFold(r);
+    ret[i] = runeFold(r);
   }
   if (len)
     *len = rlen;

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -42,7 +42,7 @@ rune __runeToFold(rune r) {
     return r;
   }
   nu_casemap_read(map, &loweredRune);
-  return loweredRune;
+  return loweredRune & TRIE_RUNE_MASK;
 }
 
 // implementation is identical to that of

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -33,3 +33,34 @@ char *__runesToStr(rune *in, size_t len, size_t *utflen) {
   nu_writestr(unicode, ret, nu_utf8_write);
   return ret;
 }
+
+rune __runeToFold(rune r) {
+  uint32_t loweredRune = 0;
+  const char *map = 0;
+  map = nu_tofold(r);
+  if (!map) {
+    return r;
+  }
+  nu_casemap_read(map, &loweredRune);
+  return loweredRune;
+}
+
+// implementation is identical to that of
+// __strToRunes except for line where __runeToFold is called
+rune *__strToFoldedRunes(char *str, size_t *len) {
+
+  ssize_t rlen = nu_strlen(str, nu_utf8_read);
+  uint32_t decoded[sizeof(uint32_t) * (rlen + 1)];
+
+  nu_readstr(str, decoded, nu_utf8_read);
+
+  rune *ret = calloc(rlen + 1, sizeof(rune));
+  for (int i = 0; i < rlen; i++) {
+    rune r = (rune)decoded[i] & 0x0000FFFF;
+    ret[i] = __runeToFold(r);
+  }
+  if (len)
+    *len = rlen;
+  
+  return ret;
+}

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -12,13 +12,6 @@ static uint32_t __fold(uint32_t runelike) {
   return lowered;
 }
 
-/* where "runelike" is a 16 or 32-bit 
- * unicode codepoint, depending on whether
- TRIE_32BIT_RUNES is defined */
-static rune __toRune(uint32_t runelike) {
-  return (rune)runelike & TRIE_RUNE_MASK;
-}
-
 rune runeFold(rune r) {
   return __fold((uint32_t) r);
 }
@@ -51,7 +44,7 @@ rune *strToFoldedRunes(char *str, size_t *len) {
   rune *ret = calloc(rlen + 1, sizeof(rune));
   for (int i = 0; i < rlen; i++) {
     uint32_t runelike = decoded[i];
-    ret[i] = __toRune(__fold(runelike));
+    ret[i] = (rune)__fold(runelike);
   }
   if (len)
     *len = rlen;
@@ -68,7 +61,7 @@ rune *strToRunes(char *str, size_t *len) {
 
   rune *ret = calloc(rlen + 1, sizeof(rune));
   for (int i = 0; i < rlen; i++) {
-    ret[i] = __toRune(decoded[i]);
+    ret[i] = (rune)decoded[i];
   }
   if (len)
     *len = rlen;

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -14,13 +14,13 @@
 #endif
 
 /* Convert a utf-8 string to constant width runes */
-rune *__strToRunes(char *str, size_t *len);
+rune *strToRunes(char *str, size_t *len);
 
 /* Convert a rune string to utf-8 characters */
-char *__runesToStr(rune *in, size_t len, size_t *utflen);
+char *runesToStr(rune *in, size_t len, size_t *utflen);
 
-rune __runeToFold(rune r);
+rune runeFold(rune r);
 
-rune *__strToFoldedRunes(char *str, size_t *len);
+rune *strToFoldedRunes(char *str, size_t *len);
 
 #endif

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -6,9 +6,9 @@
 /* Internally, the trie works with 16/32 bit "Runes", i.e. fixed width unicode
  * characters. 16 bit shuold be fine for most use cases */
 #ifdef TRIE_32BIT_RUNES
-    typedef u_int32_t rune;
+    typedef uint32_t rune;
 #else // default - 16 bit runes
-    typedef u_int16_t rune;
+    typedef uint16_t rune;
 #endif
 
 /* fold rune: assumes rune is of the correct size */

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -19,4 +19,8 @@ rune *__strToRunes(char *str, size_t *len);
 /* Convert a rune string to utf-8 characters */
 char *__runesToStr(rune *in, size_t len, size_t *utflen);
 
+rune __runeToFold(rune r);
+
+rune *__strToFoldedRunes(char *str, size_t *len);
+
 #endif

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -7,10 +7,8 @@
  * characters. 16 bit shuold be fine for most use cases */
 #ifdef TRIE_32BIT_RUNES
     typedef u_int32_t rune;
-    #define TRIE_RUNE_MASK 0xffffffff
 #else // default - 16 bit runes
     typedef u_int16_t rune;
-    #define TRIE_RUNE_MASK 0x0000ffff
 #endif
 
 /* fold rune: assumes rune is of the correct size */

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -3,7 +3,7 @@
 
 #include "../dep/libnu/libnu.h"
 
-/* Internally, the trie works with 16/32 bit "Runes", i.e. fixed with unicode
+/* Internally, the trie works with 16/32 bit "Runes", i.e. fixed width unicode
  * characters. 16 bit shuold be fine for most use cases */
 #ifdef TRIE_32BIT_RUNES
     typedef u_int32_t rune;
@@ -13,14 +13,15 @@
     #define TRIE_RUNE_MASK 0x0000ffff
 #endif
 
-/* Convert a utf-8 string to constant width runes */
-rune *strToRunes(char *str, size_t *len);
+/* fold rune: assumes rune is of the correct size */
+rune runeFold(rune r);
 
 /* Convert a rune string to utf-8 characters */
 char *runesToStr(rune *in, size_t len, size_t *utflen);
 
-rune runeFold(rune r);
-
 rune *strToFoldedRunes(char *str, size_t *len);
+
+/* Convert a utf-8 string to constant width runes */
+rune *strToRunes(char *str, size_t *len);
 
 #endif

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -1,0 +1,22 @@
+#ifndef __RUNE_UTIL_H__
+#define __RUNE_UTIL_H__
+
+#include "../dep/libnu/libnu.h"
+
+/* Internally, the trie works with 16/32 bit "Runes", i.e. fixed with unicode
+ * characters. 16 bit shuold be fine for most use cases */
+#ifdef TRIE_32BIT_RUNES
+    typedef u_int32_t rune;
+    #define TRIE_RUNE_MASK 0xffffffff
+#else // default - 16 bit runes
+    typedef u_int16_t rune;
+    #define TRIE_RUNE_MASK 0x0000ffff
+#endif
+
+/* Convert a utf-8 string to constant width runes */
+rune *__strToRunes(char *str, size_t *len);
+
+/* Convert a rune string to utf-8 characters */
+char *__runesToStr(rune *in, size_t len, size_t *utflen);
+
+#endif

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -4,18 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "rune_util.h"
 
 typedef u_int8_t t_len;
-
-/* Internally, the trie works with 16/32 bit "Runes", i.e. fixed with unicode
- * characters. 16 bit shuold be fine for most use cases */
-#ifdef TRIE_32BIT_RUNES
-    typedef u_int32_t rune;
-    #define TRIE_RUNE_MASK 0xffffffff
-#else // default - 16 bit runes
-    typedef u_int16_t rune;
-    #define TRIE_RUNE_MASK 0x0000ffff
-#endif
 
 #define MAX_STRING_LEN 255
 

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -63,7 +63,7 @@ Vector *Trie_Search(Trie *tree, char *s, size_t len, size_t num, int maxDist, in
   heap_init(pq, cmpEntries, NULL, num);
 
   size_t rlen;
-  rune *runes = __strToRunes(s, &rlen);
+  rune *runes = __strToFoldedRunes(s, &rlen);
   DFAFilter fc = NewDFAFilter(runes, rlen, maxDist, prefixMode);
 
   TrieIterator *it = TrieNode_Iterate(tree->root, FilterFunc, StackPop, &fc);

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -2,44 +2,11 @@
 #include "../rmutil/strings.h"
 #include "../rmutil/util.h"
 #include "../util/heap.h"
+#include "rune_util.h"
 #include "trie_type.h"
 #include <math.h>
 #include <sys/param.h>
 #include <time.h>
-
-/* Convert a utf-8 string to constant width runes */
-rune *__strToRunes(char *str, size_t *len) {
-
-  ssize_t rlen = nu_strlen(str, nu_utf8_read);
-  uint32_t decoded[sizeof(uint32_t) * (rlen + 1)];
-
-  nu_readstr(str, decoded, nu_utf8_read);
-
-  rune *ret = calloc(rlen + 1, sizeof(rune));
-  for (int i = 0; i < rlen; i++) {
-    ret[i] = (rune)decoded[i] & 0x0000FFFF;
-  }
-  if (len) *len = rlen;
-
-  return ret;
-}
-
-/* Convert a rune string to utf-8 characters */
-char *__runesToStr(rune *in, size_t len, size_t *utflen) {
-
-  uint32_t unicode[len + 1];
-  for (int i = 0; i < len; i++) {
-    unicode[i] = (uint32_t)in[i] & 0x0000ffff;
-  }
-  unicode[len] = 0;
-
-  *utflen = nu_bytelen(unicode, nu_utf8_write);
-
-  char *ret = calloc(1, *utflen + 1);
-
-  nu_writestr(unicode, ret, nu_utf8_write);
-  return ret;
-}
 
 Trie *NewTrie() {
   Trie *tree = RedisModule_Alloc(sizeof(Trie));


### PR DESCRIPTION
close #11 (Normalize and fold Unicode text in auto-complete)

After this change, `ft.SUGADD` and `ft.SUGGET` work like this:

```sh
127.0.0.1:6379> FLUSHALL
OK
127.0.0.1:6379> ft.SUGADD ac "hello WorlD ß" 100
(integer) 1
127.0.0.1:6379> ft.SUGGET ac "HELLO"
1) "hello world ss"
127.0.0.1:6379> 
```

Notes:

1. I couldn't get all the Python tests to pass, but this seems to work in the CLI
1. It would be nice to add a test case to the Python tests that covers multiple code points, like in the above example, but I couldn't get that to work—Python always complained about `\xc3` when I used `\xc3` or `ß`
1. I followed what's currently in the project and used `malloc` instead of [`RedisModule_Alloc`](https://github.com/antirez/redis/blob/unstable/src/modules/API.md#rm_alloc). For my own learning, why does the project use raw `malloc`?
1. I wasn't sure where to stick the functions **fold_str.c**. Do they belong in an existing file somewhere?
1. I'm not sure if my variable names made sense, since I'm still trying to understand what the libnu functions do

Thanks for taking a look!

