### PR TITLE
Patches for OSX compilation warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,13 +2,11 @@
 # find the OS
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
-CFLAGS= -Wall -Wno-unused-function -Wno-unused-variable -Wno-pointer-sign -fPIC  -std=gnu99 -I./
+CFLAGS= -Wall -Werror -Wno-unused-function -Wno-unused-variable -Wno-pointer-sign -fPIC  -std=gnu99 -I./
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
 	SHOBJ_CFLAGS ?= -fno-common -g -ggdb
 	SHOBJ_LDFLAGS ?= -shared -Bsymbolic -Bsymbolic-functions
-	# We add -Werror to CFLAGS only on Linux since on OSX there are still tons of warnings
-	CFLAGS +=-Werror  
 else
 	SHOBJ_CFLAGS ?= -dynamic -fno-common -g -ggdb
 	SHOBJ_LDFLAGS ?= -bundle -undefined dynamic_lookup

--- a/src/module.c
+++ b/src/module.c
@@ -9,6 +9,7 @@
 #include "rmutil/strings.h"
 #include "rmutil/util.h"
 #include "spec.h"
+#include "stopwords.h"
 #include "tokenize.h"
 #include "trie/trie_type.h"
 #include "util/logging.h"

--- a/src/query_parser/tokenizer.c
+++ b/src/query_parser/tokenizer.c
@@ -1,3 +1,4 @@
+#include "stopwords.h"
 #include "tokenizer.h"
 #include "parser.h"
 #include "../tokenize.h"

--- a/src/query_parser/tokenizer.h
+++ b/src/query_parser/tokenizer.h
@@ -2,12 +2,7 @@
 #define __QUERY_TOKENIZER_H__
 
 #include <stdlib.h>
-
-#include "../stopwords.h"
-
-// A NormalizeFunc converts a raw token to the normalized form in which it will
-// be stored
-typedef char *(*NormalizeFunc)(char *, size_t *);
+#include "../tokenize.h"
 
 /* A query-specific tokenizer, that reads symbols like quots, pipes, etc */
 typedef struct {

--- a/src/tests/test_query.c
+++ b/src/tests/test_query.c
@@ -1,6 +1,7 @@
 #include "../expander.h"
 #include "../query.h"
 #include "../query_parser/tokenizer.h"
+#include "stopwords.h"
 #include "test_util.h"
 #include "time_sample.h"
 #include <stdio.h>

--- a/src/tests/test_range.c
+++ b/src/tests/test_range.c
@@ -5,16 +5,24 @@
 #include "../index.h"
 #include "../rmutil/alloc.h"
 
+// Helper so we get the same pseudo-random numbers
+// in tests across environments
+u_int prng_seed = 1337;
+#define PRNG_MOD 30980347
+u_int prng() {
+  prng_seed = (prng_seed * prng_seed) % PRNG_MOD;
+  return prng_seed;
+}
+
 int testNumericRangeTree() {
   NumericRangeTree *t = NewNumericRangeTree();
   ASSERT(t != NULL);
 
-  srand(1337);
   for (int i = 0; i < 50000; i++) {
 
-    NumericRangeTree_Add(t, i + 1, (double)(1 + rand() % 5000));
+    NumericRangeTree_Add(t, i + 1, (double)(1 + prng() % 5000));
   }
-  ASSERT_EQUAL(t->numRanges, 60);
+  ASSERT_EQUAL(t->numRanges, 44);
   ASSERT_EQUAL(t->numEntries, 50000);
 
   struct {
@@ -39,13 +47,6 @@ int testNumericRangeTree() {
   }
   NumericRangeTree_Free(t);
   return 0;
-}
-
-u_int prng_seed = 1337;
-#define PRNG_MOD 30980347
-u_int prng() {
-  prng_seed = (prng_seed * prng_seed) % PRNG_MOD;
-  return prng_seed;
 }
 
 int testRangeIterator() {

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -1,4 +1,5 @@
 #include "forward_index.h"
+#include "stopwords.h"
 #include "tokenize.h"
 #include <ctype.h>
 #include <stdlib.h>

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -3,7 +3,6 @@
 #define __TOKENIZE_H__
 
 #include "stemmer.h"
-#include "stopwords.h"
 #include "types.h"
 #include "util/khash.h"
 #include "varint.h"

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -88,7 +88,7 @@ Vector *Trie_Search(Trie *tree, char *s, size_t len, size_t num, int maxDist, in
     }
     // in prefix mode we also factor in the total length of the suffix
     if (prefixMode) {
-      ent->score /= sqrt(1 + fabs(slen - len));
+      ent->score /= sqrt(1 + (slen >= len ? slen - len : len - slen));
     }
 
     if (heap_count(pq) < heap_size(pq)) {


### PR DESCRIPTION
Fix compilation warnings caught on OS X:
- NormalizeFunc was defined twice: remove the duplicate and fix
up `#include`s
- Avoid unsigned integer overflow bug vector in trie_type.c:
`slen-len` isn't safe when the lengths are unsigned.

Also modified the main Makefile to use the `-Werror` flag in all environments, since OS X doesn't complain anymore.