### PR TITLE
Better Protection against race conditions in concurrent execution

### DIFF
--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -16,6 +16,7 @@ void ConcurrentSearch_ThreadPoolRun(void (*func)(void *), void *arg) {
 }
 
 void ConcurrentSearch_CloseKeys(ConcurrentSearchCtx *ctx) {
+
   size_t sz = ctx->numOpenKeys;
   for (size_t i = 0; i < sz; i++) {
     RedisModule_CloseKey(ctx->openKeys[i].key);

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -28,6 +28,10 @@
  */
 
 typedef void (*ConcurrentReopenCallback)(RedisModuleKey *k, void *ctx);
+
+/* ConcurrentKeyCtx is a reference to a key that's being held open during concurrent execution and
+ * needs to be reopened after yielding and gaining back execution. See ConcurrentSearch_AddKey for
+ * more details */
 typedef struct {
   RedisModuleKey *key;
   RedisModuleString *keyName;
@@ -38,6 +42,7 @@ typedef struct {
   void (*freePrivData)(void *);
 } ConcurrentKeyCtx;
 
+/* The concurrent execution context struct itself. See above for details */
 typedef struct {
   long long ticker;
   struct timespec lastTime;
@@ -58,9 +63,23 @@ typedef struct {
 /** The timeout after which we try to switch to another query thread - in Nanoseconds */
 #define CONCURRENT_TIMEOUT_NS 50000
 
+/* Add a "monitored" key to the context. When keys are open during concurrent execution, they need
+ * to be closed before we yield execution and release the GIL, and reopened when we get back the
+ * execution context.
+ * To simplify this, each place in the program that holds a reference to a redis key
+ * based data, registers itself and the key to be automatically reopened.
+ *
+ * After reopening, a callback
+ * is being called to notify the key holder that it has been reopened, and handle the consequences.
+ * This is used by index iterators to avoid holding reference to deleted keys or changed data.
+ *
+ * We register the key, the flags to reopen it, a string holding its name for reopening, a callback
+ * for notification, and private callback data. if freePrivDataCallback is provided, we will call it
+ * when the context is freed to release the private data. If NULL is passed, we do nothing */
 void ConcurrentSearch_AddKey(ConcurrentSearchCtx *ctx, RedisModuleKey *key, int openFlags,
                              RedisModuleString *keyName, ConcurrentReopenCallback cb,
                              void *privdata, void (*freePrivDataCallback)(void *));
+
 /** Start the concurrent search thread pool. Should be called when initializing the module */
 void ConcurrentSearch_ThreadPoolStart();
 
@@ -73,6 +92,7 @@ void ConcurrentSearch_CheckTimer(ConcurrentSearchCtx *ctx);
 /** Initialize and reset a concurrent search ctx */
 void ConcurrentSearchCtx_Init(RedisModuleCtx *rctx, ConcurrentSearchCtx *ctx);
 
+/* Free the execution context's dynamically allocated resources */
 void ConcurrentSearchCtx_Free(ConcurrentSearchCtx *ctx);
 
 /** This macro is called by concurrent executors (currently the query only).

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -31,9 +31,11 @@ typedef void (*ConcurrentReopenCallback)(RedisModuleKey *k, void *ctx);
 typedef struct {
   RedisModuleKey *key;
   RedisModuleString *keyName;
-  void *ctx;
+  void *privdata;
   ConcurrentReopenCallback cb;
   int keyFlags;
+  // A custom callback to free privdata. If NULL we don't do anything
+  void (*freePrivData)(void *);
 } ConcurrentKeyCtx;
 
 typedef struct {
@@ -58,7 +60,7 @@ typedef struct {
 
 void ConcurrentSearch_AddKey(ConcurrentSearchCtx *ctx, RedisModuleKey *key, int openFlags,
                              RedisModuleString *keyName, ConcurrentReopenCallback cb,
-                             void *privdata);
+                             void *privdata, void (*freePrivDataCallback)(void *));
 /** Start the concurrent search thread pool. Should be called when initializing the module */
 void ConcurrentSearch_ThreadPoolStart();
 

--- a/src/id_list.c
+++ b/src/id_list.c
@@ -25,6 +25,10 @@ int IL_Read(void *ctx, RSIndexResult **r) {
   return INDEXREAD_OK;
 }
 
+void IL_Abort(void *ctx) {
+  ((IdListIterator *)ctx)->atEOF = 1;
+}
+
 /* Skip to a docid, potentially reading the entry into hit, if the docId
  * matches */
 int IL_SkipTo(void *ctx, uint32_t docId, RSIndexResult **r) {
@@ -136,5 +140,6 @@ IndexIterator *NewIdListIterator(t_docId *ids, t_offset num) {
   ret->Read = IL_Read;
   ret->Current = IL_Current;
   ret->SkipTo = IL_SkipTo;
+  ret->Abort = IL_Abort;
   return ret;
 }

--- a/src/index_iterator.h
+++ b/src/index_iterator.h
@@ -37,6 +37,10 @@ typedef struct indexIterator {
   /* Return the number of results in this iterator. Used by the query execution
    * on the top iterator */
   size_t (*Len)(void *ctx);
+
+  /* Abort the execution of the iterator and mark it as EOF. This is used for early aborting in case
+   * of data consistency issues due to multi threading */
+  void (*Abort)(void *ctx);
 } IndexIterator;
 
 #endif

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -497,15 +497,18 @@ int IR_SkipTo(void *ctx, uint32_t docId, RSIndexResult **hit) {
     return IR_Read(ctx, hit);
   }
 
+  if (ir->atEnd) {
+    goto eof;
+  }
+
   /* check if the id is out of range */
   if (docId > ir->idx->lastId) {
-    ir->atEnd = 1;
-    return INDEXREAD_EOF;
+    goto eof;
   }
   // try to skip to the current block
   if (!IndexReader_SkipToBlock(ir, docId)) {
     if (IR_Read(ir, hit) == INDEXREAD_EOF) {
-      return INDEXREAD_EOF;
+      goto eof;
     }
     return INDEXREAD_NOTFOUND;
   }
@@ -518,6 +521,7 @@ int IR_SkipTo(void *ctx, uint32_t docId, RSIndexResult **hit) {
     if (rid == docId) return INDEXREAD_OK;
     return INDEXREAD_NOTFOUND;
   }
+eof:
   ir->atEnd = 1;
   return INDEXREAD_EOF;
 }

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -576,6 +576,11 @@ void IR_Free(IndexReader *ir) {
   rm_free(ir);
 }
 
+void IR_Abort(void *ctx) {
+  IndexReader *it = ctx;
+  it->atEnd = 1;
+}
+
 void ReadIterator_Free(IndexIterator *it) {
   if (it == NULL) {
     return;
@@ -599,6 +604,7 @@ IndexIterator *NewReadIterator(IndexReader *ir) {
   ri->Free = ReadIterator_Free;
   ri->Len = IR_NumDocs;
   ri->Current = IR_Current;
+  ri->Abort = IR_Abort;
   return ri;
 }
 

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -87,6 +87,8 @@ typedef struct indexReadCtx {
   int atEnd;
 } IndexReader;
 
+void IndexReader_OnReopen(RedisModuleKey *k, void *privdata);
+
 /* An index encoder is a callback that writes records to the index. It accepts a pre-calculated
  * delta for encoding */
 typedef size_t (*IndexEncoder)(BufferWriter *bw, t_docId delta, RSIndexResult *record);

--- a/src/module.c
+++ b/src/module.c
@@ -259,7 +259,7 @@ int AddDocumentCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     goto cleanup;
   }
 
-  RedisSearchCtx sctx = {ctx, sp};
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
 
   // Load the document score
   double ds = 0;
@@ -510,7 +510,7 @@ int QueryExplainCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
   size_t qlen;
   const char *qs = RedisModule_StringPtrLen(argv[2], &qlen);
-  RedisSearchCtx sctx = {ctx, sp};
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   Query *q = NewQuery(&sctx, (char *)qs, qlen, 0, 10, RS_FIELDMASK_ALL, 0, "en", sp->stopwords,
                       NULL, -1, 0, NULL, (RSPayload){}, NULL);
 
@@ -646,8 +646,7 @@ int AddHashCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   int replace = RMUtil_ArgExists("REPLACE", argv, argc, 1);
 
-  RedisSearchCtx sctx = {ctx, sp};
-
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   // Load the document score
   double ds = 0;
   if (RedisModule_StringToDouble(argv[3], &ds) == REDISMODULE_ERR) {
@@ -891,8 +890,7 @@ int OptimizeIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   sp->stats.scoreIndexesSize = 0;
   sp->stats.skipIndexesSize = 0;
 
-  RedisSearchCtx sctx = {ctx, sp};
-
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   RedisModuleString *pf = fmtRedisTermKey(&sctx, "*", 1);
   size_t len;
   const char *prefix = RedisModule_StringPtrLen(pf, &len);
@@ -922,8 +920,7 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
 
-  RedisSearchCtx sctx = {ctx, sp};
-
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   Redis_DropIndex(&sctx, 1);
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -8,6 +8,7 @@
 #include "index_result.h"
 #include "redismodule.h"
 #include "search_ctx.h"
+#include "concurrent_ctx.h"
 #include "inverted_index.h"
 #include "numeric_filter.h"
 
@@ -51,6 +52,9 @@ typedef struct {
 } NumericRangeTree;
 
 struct indexIterator *NewNumericRangeIterator(NumericRange *nr, NumericFilter *f);
+
+struct indexIterator *NewNumericFilterIterator2(RedisSearchCtx *ctx, NumericFilter *flt,
+                                                ConcurrentSearchCtx *csx);
 
 struct indexIterator *NewNumericFilterIterator(NumericRangeTree *t, NumericFilter *f);
 

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -53,10 +53,8 @@ typedef struct {
 
 struct indexIterator *NewNumericRangeIterator(NumericRange *nr, NumericFilter *f);
 
-struct indexIterator *NewNumericFilterIterator2(RedisSearchCtx *ctx, NumericFilter *flt,
-                                                ConcurrentSearchCtx *csx);
-
-struct indexIterator *NewNumericFilterIterator(NumericRangeTree *t, NumericFilter *f);
+struct indexIterator *NewNumericFilterIterator(RedisSearchCtx *ctx, NumericFilter *flt,
+                                               ConcurrentSearchCtx *csx);
 
 /* Add an entry to a numeric range node. Returns the cardinality of the range after the
  * inserstion.

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -46,6 +46,8 @@ typedef struct {
   size_t numRanges;
   size_t numEntries;
   size_t card;
+
+  uint32_t revisionId;
 } NumericRangeTree;
 
 struct indexIterator *NewNumericRangeIterator(NumericRange *nr, NumericFilter *f);

--- a/src/query.c
+++ b/src/query.c
@@ -337,7 +337,7 @@ static IndexIterator *Query_EvalNumericNode(Query *q, QueryNumericNode *node) {
     return NULL;
   }
 
-  return NewNumericFilterIterator2(q->ctx, node->nf, &q->conc);
+  return NewNumericFilterIterator(q->ctx, node->nf, &q->conc);
 }
 
 static IndexIterator *Query_EvalGeofilterNode(Query *q, QueryGeofilterNode *node) {

--- a/src/query.c
+++ b/src/query.c
@@ -341,7 +341,7 @@ static IndexIterator *Query_EvalNumericNode(Query *q, QueryNumericNode *node) {
     return NULL;
   }
 
-  return NewNumericFilterIterator(t, node->nf);
+  return NewNumericFilterIterator(t, node->nf, &q->conc);
 }
 
 static IndexIterator *Query_EvalGeofilterNode(Query *q, QueryGeofilterNode *node) {

--- a/src/query.c
+++ b/src/query.c
@@ -205,8 +205,8 @@ IndexIterator *Query_EvalTokenNode(Query *q, QueryNode *qn) {
 
   int isSingleWord = q->numTokens == 1 && q->fieldMask == RS_FIELDMASK_ALL;
 
-  IndexReader *ir =
-      Redis_OpenReader(q->ctx, &qn->tn, q->docTable, isSingleWord, q->fieldMask & qn->fieldMask);
+  IndexReader *ir = Redis_OpenReader(q->ctx, &qn->tn, q->docTable, isSingleWord,
+                                     q->fieldMask & qn->fieldMask, &q->conc);
   if (ir == NULL) {
     return NULL;
   }
@@ -249,7 +249,8 @@ static IndexIterator *Query_EvalPrefixNode(Query *q, QueryNode *qn) {
     tok.str = runesToStr(rstr, slen, &tok.len);
 
     // Open an index reader
-    IndexReader *ir = Redis_OpenReader(q->ctx, &tok, q->docTable, 0, q->fieldMask & qn->fieldMask);
+    IndexReader *ir =
+        Redis_OpenReader(q->ctx, &tok, q->docTable, 0, q->fieldMask & qn->fieldMask, &q->conc);
 
     free(tok.str);
     if (!ir) continue;

--- a/src/query.h
+++ b/src/query.h
@@ -49,6 +49,8 @@ typedef struct RSQuery {
   // Whether phrases are in order or not
   int inOrder;
 
+  int aborted;
+
   // Query expander
   RSQueryTokenExpander expander;
   RSFreeFunction expanderFree;

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -108,18 +108,27 @@ RedisModuleString *fmtRedisScoreIndexKey(RedisSearchCtx *ctx, const char *term, 
 }
 
 RedisSearchCtx *NewSearchCtx(RedisModuleCtx *ctx, RedisModuleString *indexName) {
-  IndexSpec *sp = IndexSpec_Load(ctx, RedisModule_StringPtrLen(indexName, NULL), 0);
-  if (!sp) {
+
+  RedisModuleString *keyName = RedisModule_CreateStringPrintf(
+      ctx, INDEX_SPEC_KEY_FMT, RedisModule_StringPtrLen(indexName, NULL));
+
+  RedisModuleKey *k = RedisModule_OpenKey(ctx, keyName, REDISMODULE_READ);
+  // printf("open key %s: %p\n", RedisModule_StringPtrLen(keyName, NULL), k);
+  // we do not allow empty indexes when loading an existing index
+  if (k == NULL || RedisModule_ModuleTypeGetType(k) != IndexSpecType) {
     return NULL;
   }
+  IndexSpec *sp = RedisModule_ModuleTypeGetValue(k);
 
   RedisSearchCtx *sctx = rm_malloc(sizeof(*sctx));
-  sctx->spec = sp;
-  sctx->redisCtx = ctx;
+  *sctx = (RedisSearchCtx){
+      .spec = sp, .redisCtx = ctx, .key = k, .keyName = keyName,
+  };
   return sctx;
 }
 
 void SearchCtx_Free(RedisSearchCtx *sctx) {
+
   rm_free(sctx);
 }
 /*
@@ -236,10 +245,11 @@ IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSToken *tok, DocTable *dt, i
 
   RedisModuleString *termKey = fmtRedisTermKey(ctx, tok->str, tok->len);
   RedisModuleKey *k = RedisModule_OpenKey(ctx->redisCtx, termKey, REDISMODULE_READ);
-  // RedisModule_FreeString(ctx->redisCtx, termKey);
+
   // we do not allow empty indexes when loading an existing index
   if (k == NULL || RedisModule_KeyType(k) == REDISMODULE_KEYTYPE_EMPTY ||
       RedisModule_ModuleTypeGetType(k) != InvertedIndexType) {
+    RedisModule_FreeString(ctx->redisCtx, termKey);
     return NULL;
   }
 
@@ -247,7 +257,7 @@ IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSToken *tok, DocTable *dt, i
 
   IndexReader *ret = NewTermIndexReader(idx, dt, fieldMask, NewTerm(tok));
   if (csx) {
-    ConcurrentSearch_AddKey(csx, k, REDISMODULE_READ, termKey, IndexReader_OnReopen, ret);
+    ConcurrentSearch_AddKey(csx, k, REDISMODULE_READ, termKey, IndexReader_OnReopen, ret, NULL);
   }
   return ret;
 }

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -232,11 +232,11 @@ InvertedIndex *Redis_OpenInvertedIndex(RedisSearchCtx *ctx, const char *term, si
 }
 
 IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSToken *tok, DocTable *dt, int singleWordMode,
-                              t_fieldMask fieldMask) {
+                              t_fieldMask fieldMask, ConcurrentSearchCtx *csx) {
 
   RedisModuleString *termKey = fmtRedisTermKey(ctx, tok->str, tok->len);
   RedisModuleKey *k = RedisModule_OpenKey(ctx->redisCtx, termKey, REDISMODULE_READ);
-  RedisModule_FreeString(ctx->redisCtx, termKey);
+  // RedisModule_FreeString(ctx->redisCtx, termKey);
   // we do not allow empty indexes when loading an existing index
   if (k == NULL || RedisModule_KeyType(k) == REDISMODULE_KEYTYPE_EMPTY ||
       RedisModule_ModuleTypeGetType(k) != InvertedIndexType) {
@@ -245,7 +245,11 @@ IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSToken *tok, DocTable *dt, i
 
   InvertedIndex *idx = RedisModule_ModuleTypeGetValue(k);
 
-  return NewTermIndexReader(idx, dt, fieldMask, NewTerm(tok));
+  IndexReader *ret = NewTermIndexReader(idx, dt, fieldMask, NewTerm(tok));
+  if (csx) {
+    ConcurrentSearch_AddKey(csx, k, REDISMODULE_READ, termKey, IndexReader_OnReopen, ret);
+  }
+  return ret;
 }
 
 // void Redis_CloseReader(IndexReader *r) {

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -5,13 +5,14 @@
 #include "index.h"
 #include "inverted_index.h"
 #include "search_ctx.h"
+#include "concurrent_ctx.h"
 #include "spec.h"
 
 /* Open an inverted index reader on a redis DMA string, for a specific term.
  * If singleWordMode is set to 1, we do not load the skip index, only the score index
  */
 IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSToken *tok, DocTable *dt, int singleWordMode,
-                              t_fieldMask fieldMask);
+                              t_fieldMask fieldMask, ConcurrentSearchCtx *csx);
 
 InvertedIndex *Redis_OpenInvertedIndex(RedisSearchCtx *ctx, const char *term, size_t len,
                                        int write);

--- a/src/search_ctx.h
+++ b/src/search_ctx.h
@@ -11,9 +11,15 @@
 /** Context passed to all redis related search handling functions. */
 typedef struct {
   RedisModuleCtx *redisCtx;
+  RedisModuleKey *key;
+  RedisModuleString *keyName;
   IndexSpec *spec;
 } RedisSearchCtx;
 
+#define SEARCH_CTX_STATIC(ctx, sp) \
+  (RedisSearchCtx) {               \
+    .redisCtx = ctx, .spec = sp    \
+  }
 RedisSearchCtx *NewSearchCtx(RedisModuleCtx *ctx, RedisModuleString *indexName);
 void SearchCtx_Free(RedisSearchCtx *sctx);
 #endif

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -392,6 +392,26 @@ int testNumericInverted() {
   return 0;
 }
 
+int testAbort() {
+
+  InvertedIndex *w = createIndex(1000, 1);
+  IndexReader *r = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL);  //
+
+  IndexIterator *it = NewReadIterator(r);
+  int n = 0;
+  RSIndexResult *res;
+  while (INDEXREAD_EOF != it->Read(it->ctx, &res)) {
+    if (n == 50) {
+      it->Abort(it->ctx);
+    }
+    n++;
+  }
+  ASSERT_EQUAL(51, n);
+  it->Free(it);
+  InvertedIndex_Free(w);
+  return 0;
+}
+
 int testIntersection() {
 
   InvertedIndex *w = createIndex(100000, 4);
@@ -795,22 +815,22 @@ TEST_MAIN({
 
   // LOGGING_INIT(L_INFO);
   RMUTil_InitAlloc();
-
+  TESTFUNC(testAbort)
   TESTFUNC(testNumericInverted);
 
-  // TESTFUNC(testVarint);
-  // TESTFUNC(testDistance);
-  // TESTFUNC(testIndexReadWrite);
+  TESTFUNC(testVarint);
+  TESTFUNC(testDistance);
+  TESTFUNC(testIndexReadWrite);
 
-  // TESTFUNC(testReadIterator);
-  // TESTFUNC(testIntersection);
-  // TESTFUNC(testNot);
-  // TESTFUNC(testUnion);
+  TESTFUNC(testReadIterator);
+  TESTFUNC(testIntersection);
+  TESTFUNC(testNot);
+  TESTFUNC(testUnion);
 
-  // TESTFUNC(testBuffer);
-  // TESTFUNC(testTokenize);
-  // TESTFUNC(testIndexSpec);
-  // TESTFUNC(testIndexFlags);
-  // TESTFUNC(testDocTable);
-  // TESTFUNC(testSortable);
+  TESTFUNC(testBuffer);
+  TESTFUNC(testTokenize);
+  TESTFUNC(testIndexSpec);
+  TESTFUNC(testIndexFlags);
+  TESTFUNC(testDocTable);
+  TESTFUNC(testSortable);
 });

--- a/src/tests/test_range.c
+++ b/src/tests/test_range.c
@@ -52,6 +52,9 @@ int testNumericRangeTree() {
 #define _min(x, y) (x < y ? x : y)
 #define _max(x, y) (x < y ? y : x)
 
+// declaration for an internal function implemented in numeric_index.c
+IndexIterator *createNumericIterator(NumericRangeTree *t, NumericFilter *f);
+
 int testRangeIterator() {
   NumericRangeTree *t = NewNumericRangeTree();
   ASSERT(t != NULL);
@@ -84,7 +87,7 @@ int testRangeIterator() {
     }
 
     // printf("Testing range %f..%f, should have %d docs\n", min, max, count);
-    IndexIterator *it = NewNumericFilterIterator(t, flt);
+    IndexIterator *it = createNumericIterator(t, flt);
 
     int xcount = 0;
     RSIndexResult *res = NULL;
@@ -153,7 +156,7 @@ int benchmarkNumericRangeTree() {
   TimeSample ts;
 
   NumericFilter *flt = NewNumericFilter(1000, 50000, 0, 0);
-  IndexIterator *it = NewNumericFilterIterator(t, flt);
+  IndexIterator *it = createNumericIterator(t, flt);
   ASSERT(it->HasNext(it->ctx));
 
   // ASSERT_EQUAL(it->Len(it->ctx), N);


### PR DESCRIPTION
This PR addresses an inherent problem with concurrent search on redis:

Concurrent search works by switching between queries running on multiple threads, having just one query hold the redis global lock at a time. 

While this works well, there is the problem of what happens when a key has been deleted while a thread holding a reference to it was asleep.  Until now this would have crashed redis. 

This PR introduces a mechanism to re-acquire all the open keys after a thread sleeps, and aborting the query if a key it operates on has been deleted, or modified in a way that cannot allow the query to continue running. It does so by allowing a registry of open keys, automatically reopening them when concurrent execution is regained - and notifying their holder of the change, allowing aborting of query processing. 

A text search query will only abort if a key holding any of the terms the query operates on gets deleted while the query is running. 

A numeric range will abort if the tree holding the numeric ranges has either been deleted, or its structure changed (this is extremely rare). In this case only the currently running queries will abort with a partial result. 