### PR TITLE
Issue #126: Support `NOSTEM`

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -7,7 +7,7 @@
   FT.CREATE {index} 
     [NOOFFSETS] [NOFIELDS] [NOSCOREIDX]
     [STOPWORDS {num} {stopword} ...]
-    SCHEMA {field} [TEXT NOSTEM [WEIGHT {weight}] | NUMERIC | GEO] [SORTABLE] ...
+    SCHEMA {field} [TEXT [NOSTEM] [WEIGHT {weight}] | NUMERIC | GEO] [SORTABLE] ...
 ```
 
 ### Description:

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -7,7 +7,7 @@
   FT.CREATE {index} 
     [NOOFFSETS] [NOFIELDS] [NOSCOREIDX]
     [STOPWORDS {num} {stopword} ...]
-    SCHEMA {field} [TEXT [WEIGHT {weight}] | NUMERIC | GEO] [SORTABLE] ...
+    SCHEMA {field} [TEXT NOSTEM [WEIGHT {weight}] | NUMERIC | GEO] [SORTABLE] ...
 ```
 
 ### Description:
@@ -38,6 +38,8 @@ so keep it short!
 They can be numeric, textual or geographical. For textual fields we optionally specify a weight. The default weight is 1.0.
 
     Numeric or text field can have the optional SORTABLE argument that allows the user to later [sort the results by the value of this field](/Sorting) (this adds memory overhead so do not declare it on large text fields).
+    Text fields can have the NOSTEM argument which will disable stemming when indexing its values. 
+    This may be ideal for things like proper names
 
 ### Complexity
 O(1)

--- a/src/module.c
+++ b/src/module.c
@@ -310,6 +310,10 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
       RedisModule_ReplyWithSimpleString(ctx, "SORTABLE");
       ++nn;
     }
+    if (FieldSpec_IsNoStem(&sp->fields[i])) {
+      RedisModule_ReplyWithSimpleString(ctx, "NOSTEM");
+      ++nn;
+    }
     RedisModule_ReplySetArrayLength(ctx, nn);
   }
   n += 2;

--- a/src/module.c
+++ b/src/module.c
@@ -306,7 +306,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (sp->fields[i].type == F_FULLTEXT) {
       REPLY_KVNUM(nn, "weight", sp->fields[i].weight);
     }
-    if (sp->fields[i].sortable) {
+    if (FieldSpec_IsSortable(&sp->fields[i])) {
       RedisModule_ReplyWithSimpleString(ctx, "SORTABLE");
       ++nn;
     }
@@ -671,7 +671,7 @@ int SearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 /*
 ## FT.CREATE {index} [NOOFFSETS] [NOFIELDS] [NOSCOREIDX]
-    SCHEMA {field} [TEXT [WEIGHT {weight}]] | [NUMERIC] ...
+    SCHEMA {field} [TEXT [NOSTEM] [WEIGHT {weight}]] | [NUMERIC] ...
 
 Creates an index with the given spec. The index name will be used in all the
 key

--- a/src/spec.h
+++ b/src/spec.h
@@ -21,6 +21,7 @@ typedef enum fieldType { F_FULLTEXT, F_NUMERIC, F_GEO, F_TAG } FieldType;
 #define SPEC_SCHEMA_STR "SCHEMA"
 #define SPEC_TEXT_STR "TEXT"
 #define SPEC_WEIGHT_STR "WEIGHT"
+#define SPEC_NOSTEM_STR "NOSTEM"
 #define SPEC_TAG_STR "TAG"
 #define SPEC_SORTABLE_STR "SORTABLE"
 #define SPEC_STOPWORDS_STR "STOPWORDS"
@@ -33,6 +34,8 @@ static const char *SpecTypeNames[] = {[F_FULLTEXT] = SPEC_TEXT_STR, [F_NUMERIC] 
 
 #define SPEC_MAX_FIELDS 32
 
+typedef enum { FieldSpec_Sortable = 0x01, FieldSpec_NoStemming = 0x02 } FieldSpecOptions;
+
 /* The fieldSpec represents a single field in the document's field spec.
 Each field has a unique id that's a power of two, so we can filter fields
 by a bit mask.
@@ -42,14 +45,17 @@ typedef struct fieldSpec {
   FieldType type;
   double weight;
   t_fieldMask id;
+  FieldSpecOptions options;
 
-  int sortable;
   int sortIdx;
 
   // TODO: const char **separators;
   // size_t numSeparators;
   // TODO: More options here..
 } FieldSpec;
+
+#define FieldSpec_IsSortable(fs) ((fs)->options & FieldSpec_Sortable)
+#define FieldSpec_IsNoStem(fs) ((fs)->options & FieldSpec_NoStemming)
 
 typedef struct {
   size_t numDocuments;

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -549,10 +549,11 @@ int testTokenize() {
 
 int testIndexSpec() {
 
-  const char *title = "title", *body = "body", *foo = "foo", *bar = "bar";
-  const char *args[] = {"STOPWORDS", "2",        "hello", "world",   "SCHEMA",  title, "text",
-                        "weight",    "0.1",      body,    "text",    "weight",  "2.0", foo,
-                        "text",      "sortable", bar,     "numeric", "sortable"};
+  const char *title = "title", *body = "body", *foo = "foo", *bar = "bar", *name = "name";
+  const char *args[] = {"STOPWORDS", "2",      "hello", "world",    "SCHEMA", title,
+                        "text",      "weight", "0.1",   body,       "text",   "weight",
+                        "2.0",       foo,      "text",  "sortable", bar,      "numeric",
+                        "sortable",  name,     "text",  "nostem"};
 
   char *err = NULL;
 
@@ -562,7 +563,7 @@ int testIndexSpec() {
   }
   ASSERT(s != NULL);
   ASSERT(err == NULL);
-  ASSERT(s->numFields == 4)
+  ASSERT(s->numFields == 5)
 
   ASSERT(s->stopwords != NULL);
   ASSERT(s->stopwords != DefaultStopWordList());
@@ -581,7 +582,7 @@ int testIndexSpec() {
   ASSERT(strcmp(f->name, body) == 0);
   ASSERT(f->weight == 2.0);
   ASSERT(f->id == 2);
-  ASSERT(f->sortable == 0);
+  ASSERT(f->options == 0);
   ASSERT(f->sortIdx == -1);
 
   f = IndexSpec_GetField(s, title, strlen(title));
@@ -590,7 +591,7 @@ int testIndexSpec() {
   ASSERT(strcmp(f->name, title) == 0);
   ASSERT(f->weight == 0.1);
   ASSERT(f->id == 1);
-  ASSERT(f->sortable == 0);
+  ASSERT(f->options == 0);
   ASSERT(f->sortIdx == -1);
 
   f = IndexSpec_GetField(s, foo, strlen(foo));
@@ -599,7 +600,7 @@ int testIndexSpec() {
   ASSERT(strcmp(f->name, foo) == 0);
   ASSERT(f->weight == 1);
   ASSERT(f->id == 4);
-  ASSERT(f->sortable == 1);
+  ASSERT(f->options == FieldSpec_Sortable);
   ASSERT(f->sortIdx == 0);
 
   f = IndexSpec_GetField(s, bar, strlen(bar));
@@ -608,9 +609,18 @@ int testIndexSpec() {
   ASSERT(strcmp(f->name, bar) == 0);
   ASSERT(f->weight == 0);
   ASSERT(f->id == 0);
-  ASSERT(f->sortable == 1);
+  ASSERT(f->options == FieldSpec_Sortable);
   ASSERT(f->sortIdx == 1);
   ASSERT(IndexSpec_GetField(s, "fooz", 4) == NULL)
+
+  f = IndexSpec_GetField(s, name, strlen(name));
+  ASSERT(f != NULL);
+  ASSERT(f->type == F_FULLTEXT);
+  ASSERT(strcmp(f->name, name) == 0);
+  ASSERT(f->weight == 1);
+  ASSERT(f->id == 8);
+  ASSERT(f->options == FieldSpec_NoStemming);
+  ASSERT(f->sortIdx == -1);
 
   ASSERT(s->sortables != NULL);
   ASSERT(s->sortables->len == 2);


### PR DESCRIPTION
`NOSTEM` can now be added as a keyword when creating a text field.