### PR TITLE
Partial update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ compiler: gcc
 dist: trusty
 install: make clean && make -j 4
 before_script:
-- sudo pip install redis 
-- pip install ramp-packer rmtest
+- pip install --user redis ramp-packer rmtest
 - git clone -b 4.0.1 --depth 1 https://github.com/antirez/redis.git
 - cd redis
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ compiler: gcc
 dist: trusty
 install: make clean && make -j 4
 before_script:
-- pip install redis ramp-packer rmtest
+- sudo pip install redis 
+- pip install ramp-packer rmtest
 - git clone -b 4.0.1 --depth 1 https://github.com/antirez/redis.git
 - cd redis
 - make

--- a/src/document.c
+++ b/src/document.c
@@ -94,6 +94,7 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *base) {
       aCtx->fspecs[i] = *fs;
       if (FieldSpec_IsSortable(fs) && aCtx->sv == NULL) {
         aCtx->sv = NewSortingVector(sp->sortables->len);
+        aCtx->options |= DOCUMENT_ADD_HAS_SORTABLES;
       }
       if (fs->type != F_FULLTEXT) {
         aCtx->stateFlags |= ACTX_F_NONTXTFLDS;

--- a/src/document.c
+++ b/src/document.c
@@ -39,24 +39,12 @@ static void freeDocumentContext(void *p) {
 static void AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp, Document *base,
                                        size_t oldFieldCount) {
   aCtx->doc = *base;
-
-  // Also, get the field specs. We cache this here because the
-  // context is unlocked
-  // during the actual tokenization
   Document *doc = &aCtx->doc;
 
-  // We might be able to use the old block of fields. But, if it's too small,
-  // just free and call malloc again; that's basically what realloc does
-  // anyway.
-  if (oldFieldCount != 0 && oldFieldCount < doc->numFields) {
-    free(aCtx->fspecs);
-    free(aCtx->fdatas);
-    oldFieldCount = 0;
-  }
-
-  if (oldFieldCount == 0) {
-    aCtx->fspecs = malloc(sizeof(*aCtx->fspecs) * doc->numFields);
-    aCtx->fdatas = malloc(sizeof(*aCtx->fdatas) * doc->numFields);
+  if (oldFieldCount < doc->numFields) {
+    // Pre-allocate the field specs
+    aCtx->fspecs = realloc(aCtx->fspecs, sizeof(*aCtx->fspecs) * doc->numFields);
+    aCtx->fdatas = realloc(aCtx->fdatas, sizeof(*aCtx->fdatas) * doc->numFields);
   }
 
   for (int i = 0; i < doc->numFields; i++) {

--- a/src/document.h
+++ b/src/document.h
@@ -87,6 +87,15 @@ void Document_PrepareForAdd(Document *doc, RedisModuleString *docKey, double sco
 void Document_Detach(Document *doc, RedisModuleCtx *srcCtx);
 
 /**
+ * These two functions are used to manipulate the internal field data within a
+ * document _without_ additional allocations. ClearDetachedFields() will
+ * clear the document's field count to 0, whereas DetachFields will detach
+ * the newly loaded field data (via Redis_LoadDocument).
+ */
+void Document_ClearDetachedFields(Document *doc, RedisModuleCtx *anyCtx);
+void Document_DetachFields(Document *doc, RedisModuleCtx *ctx);
+
+/**
  * Free any copied data within the document. anyCtx is any non-NULL
  * RedisModuleCtx. The reason for requiring a context is more related to the
  * Redis Module API requiring a context for AutoMemory purposes, though in

--- a/src/document.h
+++ b/src/document.h
@@ -186,7 +186,7 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *base);
  * At this point the context will take over from the caller, and handle sending
  * the replies and so on.
  */
-void AddDocumentCtx_Submit(RSAddDocumentCtx *aCtx, RedisModuleCtx *ctx, uint32_t options);
+void AddDocumentCtx_Submit(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, uint32_t options);
 
 /**
  * Indicate that processing is finished on the current document
@@ -211,9 +211,6 @@ void AddDocumentCtx_Free(RSAddDocumentCtx *aCtx);
 
 /* Load a single document */
 int Redis_LoadDocument(RedisSearchCtx *ctx, RedisModuleString *key, Document *Doc);
-
-/* Do a quick update of the document metadata without reindexing it. TODO: possibly rename this */
-int Document_QuickUpdate(RedisSearchCtx *sctx, Document *doc, const char **errorString);
 
 /**
  * Load a single document

--- a/src/document.h
+++ b/src/document.h
@@ -103,6 +103,8 @@ void Document_FreeDetached(Document *doc, RedisModuleCtx *anyCtx);
 void Document_Free(Document *doc);
 
 #define DOCUMENT_ADD_REPLACE 0x01
+#define DOCUMENT_ADD_PARTIAL 0x02
+
 
 struct ForwardIndex;
 union FieldData;
@@ -116,6 +118,13 @@ union FieldData;
 
 // The context also has non-text fields
 #define ACTX_F_NONTXTFLDS 0x04
+
+// The content has indexable fields
+#define ACTX_F_INDEXABLES 0x08
+
+// The content has sortable fields
+#define ACTX_F_SORTABLES 0x10
+
 
 struct DocumentIndexer;
 

--- a/src/document.h
+++ b/src/document.h
@@ -14,7 +14,7 @@
 
 /**
  * To index a document, call Document_PrepareForAdd on the document itself.
- * This initializes the Document structre for indexing purposes. Once the
+ * This initializes the Document structure for indexing purposes. Once the
  * document has been prepared, acquire a new RSAddDocumentCtx() by calling
  * NewAddDocumentCtx().
  *
@@ -105,7 +105,6 @@ void Document_Free(Document *doc);
 #define DOCUMENT_ADD_REPLACE 0x01
 #define DOCUMENT_ADD_PARTIAL 0x02
 
-
 struct ForwardIndex;
 union FieldData;
 
@@ -124,7 +123,6 @@ union FieldData;
 
 // The content has sortable fields
 #define ACTX_F_SORTABLES 0x10
-
 
 struct DocumentIndexer;
 
@@ -204,6 +202,9 @@ void AddDocumentCtx_Free(RSAddDocumentCtx *aCtx);
 
 /* Load a single document */
 int Redis_LoadDocument(RedisSearchCtx *ctx, RedisModuleString *key, Document *Doc);
+
+/* Do a quick update of the document metadata without reindexing it. TODO: possibly rename this */
+int Document_QuickUpdate(RedisSearchCtx *sctx, Document *doc, const char **errorString);
 
 /**
  * Load a single document

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -367,7 +367,7 @@ static void Indexer_Process(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx) {
   for (int i = 0; i < doc->numFields; i++) {
     const FieldSpec *fs = aCtx->fspecs + i;
     fieldData *fdata = aCtx->fdatas + i;
-    if (fs->name == NULL) {
+    if (fs->name == NULL || !FieldSpec_IsIndexable(fs)) {
       // Means this document field does not have a corresponding spec
       continue;
     }

--- a/src/leakcheck.supp
+++ b/src/leakcheck.supp
@@ -2,12 +2,7 @@
    <insert_a_suppression_name_here>
    Memcheck:Leak
    match-leak-kinds: definite
-   fun:malloc
-   fun:__newTrieMapNode
-   fun:__trieMapNode_AddChild
-   fun:TrieMapNode_Add
-   fun:TrieMap_Add
-   fun:Ext_RegisterScoringFunction
+   ...
    fun:DefaultExtensionInit
    fun:Extension_Load
    fun:RediSearch_InitModuleInternal
@@ -116,6 +111,13 @@
    fun:NewIndexSpec
    fun:IndexSpec_Parse
    fun:IndexSpec_ParseRedisArgs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:DefaultStopWordList
 }
 {
    <insert_a_suppression_name_here>

--- a/src/module.c
+++ b/src/module.c
@@ -252,14 +252,18 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     int nn = 1;
     REPLY_KVSTR(nn, "type", SpecTypeNames[sp->fields[i].type]);
     if (sp->fields[i].type == F_FULLTEXT) {
-      REPLY_KVNUM(nn, "weight", sp->fields[i].weight);
+      REPLY_KVNUM(nn, SPEC_WEIGHT_STR, sp->fields[i].weight);
     }
     if (FieldSpec_IsSortable(&sp->fields[i])) {
-      RedisModule_ReplyWithSimpleString(ctx, "SORTABLE");
+      RedisModule_ReplyWithSimpleString(ctx, SPEC_SORTABLE_STR);
       ++nn;
     }
     if (FieldSpec_IsNoStem(&sp->fields[i])) {
-      RedisModule_ReplyWithSimpleString(ctx, "NOSTEM");
+      RedisModule_ReplyWithSimpleString(ctx, SPEC_NOSTEM_STR);
+      ++nn;
+    }
+    if (!FieldSpec_IsIndexable(&sp->fields[i])) {
+      RedisModule_ReplyWithSimpleString(ctx, SPEC_NOINDEX_STR);
       ++nn;
     }
     RedisModule_ReplySetArrayLength(ctx, nn);

--- a/src/module.c
+++ b/src/module.c
@@ -353,8 +353,9 @@ int QueryExplainCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   free(explain);
 
 end:
+
   Query_Free(q);
-  SearchCtx_Free(sctx);
+  RSSearchRequest_Free(req);
   return REDISMODULE_OK;
 }
 

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -374,19 +374,33 @@ class SearchTestCase(ModuleTestCase('../redisearch.so')):
             
             # Updating non indexed fields doesn't affect search results
             self.assertOk(r.execute_command('ft.add', 'idx', 'doc1', '0.1', 'replace', 'partial',
-                                                'fields',
-                                                 'num', 3, 'extra', 'jorem gipsum'))
+                                                'fields', 'num', 3, 'extra', 'jorem gipsum'))
             res = r.execute_command('ft.search', 'idx', 'hello world','sortby', 'num', 'desc',)
             self.assertListEqual([2L,'doc1', ['foo', 'hello world', 'num', '3', 'extra', 'jorem gipsum'],
                                      'doc2', ['foo', 'hello world', 'num', '2', 'extra', 'abba']], res)
+            res = r.execute_command('ft.search', 'idx', 'hello', 'nocontent', 'withscores')
             # Updating only indexed field affects search results
-            self.assertOk(r.execute_command('ft.add', 'idx', 'doc1', '0.9', 'replace', 'partial',
-                                                'fields', 'foo', 'wat wat'))
+            self.assertOk(r.execute_command('ft.add', 'idx', 'doc1', '0.1', 'replace', 'partial',
+                                                'fields', 'foo', 'wat wet'))
             res = r.execute_command('ft.search', 'idx', 'hello world', 'nocontent')
             self.assertListEqual([1L, 'doc2'], res)
             res = r.execute_command('ft.search', 'idx', 'wat', 'nocontent')
             self.assertListEqual([1L, 'doc1'], res)
 
+            # Test updating of score and no fields
+            res = r.execute_command('ft.search', 'idx', 'wat', 'nocontent', 'withscores')
+            self.assertLess(float(res[2]), 1)
+            #self.assertListEqual([1L, 'doc1'], res)
+            self.assertOk(r.execute_command('ft.add', 'idx', 'doc1', '1.0', 'replace', 'partial', 'fields'))
+            res = r.execute_command('ft.search', 'idx', 'wat', 'nocontent', 'withscores')
+            self.assertGreater(float(res[2]), 1)
+
+            # Test updating payloads
+            res = r.execute_command('ft.search', 'idx', 'wat', 'nocontent', 'withpayloads')
+            self.assertIsNone(res[2])
+            self.assertOk(r.execute_command('ft.add', 'idx', 'doc1', '1.0', 'replace', 'partial', 'payload', 'foobar', 'fields'))
+            res = r.execute_command('ft.search', 'idx', 'wat', 'nocontent', 'withpayloads')
+            self.assertEqual('foobar', res[2])
             
             
     def testPaging(self):

--- a/src/sortable.c
+++ b/src/sortable.c
@@ -169,7 +169,7 @@ RSSortingVector *SortingVector_RdbLoad(RedisModuleIO *rdb, int encver) {
   return vec;
 }
 
-/* Create a new sortin table of a given length */
+/* Create a new sorting table of a given length */
 RSSortingTable *NewSortingTable(int len) {
   RSSortingTable *tbl = rm_calloc(1, sizeof(RSSortingTable) + len * sizeof(const char *));
   tbl->len = len;

--- a/src/spec.c
+++ b/src/spec.c
@@ -131,7 +131,7 @@ int __parseFieldSpec(const char **argv, int *offset, int argc, FieldSpec *sp) {
   // if we're at the end - fail
   if (*offset >= argc) return 0;
   sp->sortIdx = -1;
-  sp->options = 0;
+  sp->options = FieldSpec_IsIndexable;
   // the field name comes here
   sp->name = rm_strdup(argv[*offset]);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -131,7 +131,7 @@ int __parseFieldSpec(const char **argv, int *offset, int argc, FieldSpec *sp) {
   // if we're at the end - fail
   if (*offset >= argc) return 0;
   sp->sortIdx = -1;
-  sp->options = FieldSpec_IsIndexable;
+  sp->options = 0;
   // the field name comes here
   sp->name = rm_strdup(argv[*offset]);
 
@@ -190,6 +190,12 @@ int __parseFieldSpec(const char **argv, int *offset, int argc, FieldSpec *sp) {
     sp->options |= FieldSpec_Sortable;
     ++*offset;
   }
+
+  if (*offset < argc && !strcasecmp(argv[*offset], SPEC_NOINDEX_STR)) {
+    sp->options |= FieldSpec_NotIndexable;
+    ++*offset;
+  }
+
   return 1;
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -182,18 +182,20 @@ int __parseFieldSpec(const char **argv, int *offset, int argc, FieldSpec *sp) {
     return 0;
   }
 
-  if (*offset < argc && !strcasecmp(argv[*offset], SPEC_SORTABLE_STR)) {
-    // cannot sort by geo fields
-    if (sp->type == F_GEO) {
-      return 0;
+  while (*offset < argc) {
+    if (!strcasecmp(argv[*offset], SPEC_SORTABLE_STR)) {
+      // cannot sort by geo fields
+      if (sp->type == F_GEO) {
+        return 0;
+      }
+      sp->options |= FieldSpec_Sortable;
+      ++*offset;
+    } else if (!strcasecmp(argv[*offset], SPEC_NOINDEX_STR)) {
+      sp->options |= FieldSpec_NotIndexable;
+      ++*offset;
+    } else {
+      break;
     }
-    sp->options |= FieldSpec_Sortable;
-    ++*offset;
-  }
-
-  if (*offset < argc && !strcasecmp(argv[*offset], SPEC_NOINDEX_STR)) {
-    sp->options |= FieldSpec_NotIndexable;
-    ++*offset;
   }
 
   return 1;

--- a/src/spec.h
+++ b/src/spec.h
@@ -25,6 +25,7 @@ typedef enum fieldType { F_FULLTEXT, F_NUMERIC, F_GEO, F_TAG } FieldType;
 #define SPEC_TAG_STR "TAG"
 #define SPEC_SORTABLE_STR "SORTABLE"
 #define SPEC_STOPWORDS_STR "STOPWORDS"
+#define SPEC_NOINDEX_STR "NOINDEX"
 
 static const char *SpecTypeNames[] = {[F_FULLTEXT] = SPEC_TEXT_STR, [F_NUMERIC] = NUMERIC_STR,
                                       [F_GEO] = GEO_STR, [F_TAG] = SPEC_TAG_STR};
@@ -34,7 +35,12 @@ static const char *SpecTypeNames[] = {[F_FULLTEXT] = SPEC_TEXT_STR, [F_NUMERIC] 
 
 #define SPEC_MAX_FIELDS 32
 
-typedef enum { FieldSpec_Sortable = 0x01, FieldSpec_NoStemming = 0x02 } FieldSpecOptions;
+
+typedef enum {
+   FieldSpec_Sortable = 0x01, 
+  FieldSpec_NoStemming = 0x02, 
+  FieldSpec_NotIndexable = 0x04
+} FieldSpecOptions;
 
 /* The fieldSpec represents a single field in the document's field spec.
 Each field has a unique id that's a power of two, so we can filter fields
@@ -56,6 +62,7 @@ typedef struct fieldSpec {
 
 #define FieldSpec_IsSortable(fs) ((fs)->options & FieldSpec_Sortable)
 #define FieldSpec_IsNoStem(fs) ((fs)->options & FieldSpec_NoStemming)
+#define FieldSpec_IsIndexable(fs) (0 == ((fs)->options & FieldSpec_Indexable))
 
 typedef struct {
   size_t numDocuments;

--- a/src/spec.h
+++ b/src/spec.h
@@ -35,10 +35,9 @@ static const char *SpecTypeNames[] = {[F_FULLTEXT] = SPEC_TEXT_STR, [F_NUMERIC] 
 
 #define SPEC_MAX_FIELDS 32
 
-
 typedef enum {
-   FieldSpec_Sortable = 0x01, 
-  FieldSpec_NoStemming = 0x02, 
+  FieldSpec_Sortable = 0x01,
+  FieldSpec_NoStemming = 0x02,
   FieldSpec_NotIndexable = 0x04
 } FieldSpecOptions;
 
@@ -62,7 +61,7 @@ typedef struct fieldSpec {
 
 #define FieldSpec_IsSortable(fs) ((fs)->options & FieldSpec_Sortable)
 #define FieldSpec_IsNoStem(fs) ((fs)->options & FieldSpec_NoStemming)
-#define FieldSpec_IsIndexable(fs) (0 == ((fs)->options & FieldSpec_Indexable))
+#define FieldSpec_IsIndexable(fs) (0 == ((fs)->options & FieldSpec_NotIndexable))
 
 typedef struct {
   size_t numDocuments;

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -383,7 +383,7 @@ int testNumericInverted() {
   RSIndexResult *res;
   t_docId i = 1;
   while (INDEXREAD_EOF != it->Read(it->ctx, &res)) {
-    printf("%d %f\n", res->docId, res->num.value);
+    // printf("%d %f\n", res->docId, res->num.value);
 
     ASSERT_EQUAL(i++, res->docId);
     ASSERT_EQUAL(res->num.value, (float)res->docId);

--- a/src/tests/test_trie.c
+++ b/src/tests/test_trie.c
@@ -179,15 +179,17 @@ int testTrie() {
   ASSERT(sc == 12);
 
   double score;
-  char *str;
+  rune *rstr;
   t_len l;
-  TrieNode *rn = TrieNode_RandomWalk(root, 10, &str, &l);
+  TrieNode *rn = TrieNode_RandomWalk(root, 10, &rstr, &l);
   ASSERT(rn != NULL);
-  ASSERT(str != NULL);
+  ASSERT(rstr != NULL);
   ASSERT(l > 0);
   // ASSERT(rn->score > 0);
+  size_t sl;
+  char *str = runesToStr(rstr, l, &sl);
   fprintf(stderr, " found node: %s\n", str);
-
+  free(rstr);
   rc = TrieNode_Delete(root, runes, rlen);
   ASSERT(rc == 1);
   rc = TrieNode_Delete(root, runes, rlen);


### PR DESCRIPTION
This adds the ability to do partial updates, and quick updates of score, payload, and sortable non indexed fields - without reindexing the document.

WIP - no documentation or tests yet.

The additions are:
1. Added the NOINDEX flag in fields, which means they will either be ignored or used for sortable only.


2. Added the PARTIAL keyword along with REPLACE in FT.ADD
in that case we check the fields in the document, and if it doesn’t contain indexable fields, we do a quick update in the main thread. If it contains indexable fields we load the new version of the document and index normally.

There are a few flags in the add document context to support this, and a flag in the field spec.