### PR TITLE
Stateful query keyword parsing

### DIFF
--- a/src/search_request.h
+++ b/src/search_request.h
@@ -20,6 +20,9 @@ typedef enum {
 
   Search_WithSortKeys = 0x40,
 
+  // Has the slop field specified.
+  Search_HasSlop = 0x80
+
 } RSSearchFlags;
 
 typedef enum {
@@ -72,7 +75,7 @@ typedef struct {
 // maximum results you can get in one query
 #define SEARCH_REQUEST_RESULTS_MAX 1000000
 
-typedef struct {
+typedef struct RSSearchRequest {
   /* The index name - since we need to open the spec in a side thread */
   char *indexName;
   /* RS Context */

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -72,7 +72,7 @@ void SortingTable_SetFieldName(RSSortingTable *tbl, int idx, const char *name);
  * default is ASC if not specified.  This function returns 1 if we found sorting args, they are
  * valid and the field name exists */
 int RSSortingTable_ParseKey(RSSortingTable *tbl, RSSortingKey *k, RedisModuleString **argv,
-                            int argc);
+                            int argc, size_t *offset);
 /* Get the field index by name from the sorting table. Returns -1 if the field was not found */
 int RSSortingTable_GetFieldIdx(RSSortingTable *tbl, const char *field);
 


### PR DESCRIPTION
This commit introduces stateful query keyword parsing, ensuring that
like-named fields (e.g. 'WITHSCORES') doesn't conflict with a search
keyword of the same value.

This framework also allows for an easier way by which to add additional
search keywords as well.