### PR TITLE
Support for up to 128 text fields

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -11,18 +11,6 @@ void Buffer_Grow(Buffer *buf, size_t extraLen) {
   buf->data = rm_realloc(buf->data, buf->cap);
 }
 
-size_t Buffer_Write(BufferWriter *bw, void *data, size_t len) {
-
-  Buffer *buf = bw->buf;
-  if (Buffer_Reserve(buf, len)) {
-    bw->pos = buf->data + buf->offset;
-  }
-  memcpy(bw->pos, data, len);
-  bw->pos += len;
-  buf->offset += len;
-  return len;
-}
-
 /**
 Truncate the buffer to newlen. If newlen is 0 - trunacte capacity
 */

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -81,7 +81,6 @@ typedef struct {
 
 } BufferWriter;
 
-size_t Buffer_Write(BufferWriter *b, void *data, size_t len);
 size_t Buffer_Truncate(Buffer *b, size_t newlen);
 
 // Ensure that at least extraLen new bytes can be added to the buffer.
@@ -94,6 +93,18 @@ static inline size_t Buffer_Reserve(Buffer *buf, size_t n) {
   }
   Buffer_Grow(buf, n);
   return 1;
+}
+
+static inline size_t Buffer_Write(BufferWriter *bw, void *data, size_t len) {
+
+  Buffer *buf = bw->buf;
+  if (Buffer_Reserve(buf, len)) {
+    bw->pos = buf->data + buf->offset;
+  }
+  memcpy(bw->pos, data, len);
+  bw->pos += len;
+  buf->offset += len;
+  return len;
 }
 
 BufferWriter NewBufferWriter(Buffer *b);

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -143,7 +143,7 @@ static khIdxEntry *makeEntry(ForwardIndex *idx, const char *s, size_t n, uint32_
 }
 
 static void ForwardIndex_HandleToken(ForwardIndex *idx, const char *tok, size_t tokLen,
-                                     uint32_t pos, float fieldScore, t_fieldMask fieldId,
+                                     uint32_t pos, float fieldScore, t_fieldId fieldId,
                                      int isStem) {
   // LG_DEBUG("token %.*s, hval %d\n", t.len, t.s, hval);
   ForwardIndexEntry *h = NULL;
@@ -178,7 +178,7 @@ static void ForwardIndex_HandleToken(ForwardIndex *idx, const char *tok, size_t 
     // printf("Existing token %.*s\n", (int)t->len, t->s);
   }
 
-  h->fieldMask |= (fieldId & RS_FIELDMASK_ALL);
+  h->fieldMask |= FIELD_BIT(fieldId);
   float score = (float)fieldScore;
 
   // stem tokens get lower score

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -39,13 +39,13 @@ typedef struct {
   const char *doc;
   VarintVectorWriter *allOffsets;
   ForwardIndex *idx;
-  t_fieldMask fieldId;
+  t_fieldId fieldId;
   float fieldScore;
 } ForwardIndexTokenizerCtx;
 
 static inline void ForwardIndexTokenizerCtx_Init(ForwardIndexTokenizerCtx *ctx, ForwardIndex *idx,
                                                  const char *doc, VarintVectorWriter *vvw,
-                                                 t_fieldMask fieldId, float score) {
+                                                 t_fieldId fieldId, float score) {
   ctx->idx = idx;
   ctx->fieldId = fieldId;
   ctx->fieldScore = score;

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -435,10 +435,29 @@ DECODER(readFreqsFlags) {
   CHECK_FLAGS(ctx, res);
 }
 
+DECODER(readFreqsFlagsWide) {
+  uint32_t maskSz;
+  qint_decode3(br, &res->docId, &res->freq, &maskSz);
+
+  Buffer_Read(br, (void *)&res->fieldMask, maskSz);
+  CHECK_FLAGS(ctx, res);
+}
+
 DECODER(readFreqOffsetsFlags) {
   // qint_decode(br, (uint32_t *)res, 4);
   qint_decode4(br, &res->docId, &res->freq, (uint32_t *)&res->fieldMask, &res->offsetsSz);
 
+  res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
+  Buffer_Skip(br, res->offsetsSz);
+  CHECK_FLAGS(ctx, res);
+}
+
+DECODER(readFreqOffsetsFlagsWide) {
+  // qint_decode(br, (uint32_t *)res, 4);
+  uint32_t maskSz;
+
+  qint_decode4(br, &res->docId, &res->freq, (uint32_t *)maskSz, &res->offsetsSz);
+  Buffer_Read(br, (void *)&res->fieldMask, maskSz);
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
   Buffer_Skip(br, res->offsetsSz);
   CHECK_FLAGS(ctx, res);
@@ -499,9 +518,27 @@ DECODER(readFlags) {
   CHECK_FLAGS(ctx, res);
 }
 
+DECODER(readFlagsWide) {
+  uint32_t maskSz;
+  qint_decode2(br, &res->docId, &maskSz);
+  Buffer_Read(br, (void *)&res->fieldMask, maskSz);
+  CHECK_FLAGS(ctx, res);
+}
+
 DECODER(readFlagsOffsets) {
   qint_decode3(br, &res->docId, (uint32_t *)&res->fieldMask, &res->offsetsSz);
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
+  Buffer_Skip(br, res->offsetsSz);
+  CHECK_FLAGS(ctx, res);
+}
+
+DECODER(readFlagsOffsetsWide) {
+  uint32_t maskSz;
+
+  qint_decode3(br, &res->docId, &maskSz, &res->offsetsSz);
+  res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
+  Buffer_Read(br, (void *)&res->fieldMask, maskSz);
+
   Buffer_Skip(br, res->offsetsSz);
   CHECK_FLAGS(ctx, res);
 }

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -430,13 +430,15 @@ static void IndexReader_AdvanceBlock(IndexReader *ir) {
 #define CHECK_FLAGS(ctx, res) return (res->fieldMask & ctx.num)
 
 DECODER(readFreqsFlags) {
-  qint_decode(br, (uint32_t *)res, 3);
+  qint_decode3(br, &res->docId, &res->freq, (uint32_t *)&res->fieldMask);
   // qint_decode3(br, &res->docId, &res->freq, &res->fieldMask);
   CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readFreqOffsetsFlags) {
-  qint_decode(br, (uint32_t *)res, 4);
+  // qint_decode(br, (uint32_t *)res, 4);
+  qint_decode4(br, &res->docId, &res->freq, (uint32_t *)&res->fieldMask, &res->offsetsSz);
+
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
   Buffer_Skip(br, res->offsetsSz);
   CHECK_FLAGS(ctx, res);
@@ -493,12 +495,12 @@ DECODER(readFreqs) {
 }
 
 DECODER(readFlags) {
-  qint_decode2(br, &res->docId, &res->fieldMask);
+  qint_decode2(br, &res->docId, (uint32_t *)&res->fieldMask);
   CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readFlagsOffsets) {
-  qint_decode3(br, &res->docId, &res->fieldMask, &res->offsetsSz);
+  qint_decode3(br, &res->docId, (uint32_t *)&res->fieldMask, &res->offsetsSz);
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
   Buffer_Skip(br, res->offsetsSz);
   CHECK_FLAGS(ctx, res);

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -721,6 +721,8 @@ static int IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
 
   // if we don't need to move beyond the current block
   if (BLOCK_MATCHES(IR_CURRENT_BLOCK(ir), docId)) return 1;
+  // the current block doesn't match and it's the last one - no point in searching
+  if (ir->currentBlock+1 == idx->size) return 0;
 
   uint32_t top = idx->size - 1;
   uint32_t bottom = ir->currentBlock + 1;
@@ -738,6 +740,7 @@ static int IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
     }
     i = (bottom + top) / 2;
   }
+
   ir->currentBlock = i;
 
 found:

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -464,7 +464,7 @@ static void IndexReader_AdvanceBlock(IndexReader *ir) {
 
 #define DECODER(name) static int name(BufferReader *br, IndexDecoderCtx ctx, RSIndexResult *res)
 
-#define CHECK_FLAGS(ctx, res) return (res->fieldMask & ctx.num)
+#define CHECK_FLAGS(ctx, res) return ((res->fieldMask & ctx.num) != 0)
 
 DECODER(readFreqsFlags) {
   qint_decode3(br, &res->docId, &res->freq, (uint32_t *)&res->fieldMask);
@@ -828,7 +828,7 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, DocTable *docTable, t_fieldM
   record->fieldMask = RS_FIELDMASK_ALL;
   record->freq = 1;
 
-  IndexDecoderCtx dctx = {.num = (uint32_t)fieldMask};
+  IndexDecoderCtx dctx = {.num = fieldMask};
 
   return NewIndexReaderGeneric(idx, decoder, dctx, record);
 }

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -38,7 +38,7 @@ struct indexReadCtx;
  * the entry */
 typedef union {
   void *ptr;
-  uint32_t num;
+  __uint128_t num;
 } IndexDecoderCtx;
 
 /* Create a new inverted index object, with the given flag. If initBlock is 1, we create the first

--- a/src/pytest/test_wideschema.py
+++ b/src/pytest/test_wideschema.py
@@ -1,0 +1,45 @@
+from rmtest import ModuleTestCase
+import redis
+import unittest
+
+
+class SearchTestCase(ModuleTestCase('../redisearch.so')):
+
+    def search(self, r, *args):
+        return r.execute_command('ft.search', *args)
+
+    def testWideSchema(self):
+        with self.redis() as r:
+            r.flushdb()
+            schema = []
+            for i in range(128):
+                schema.extend(('field_%d' % i, 'TEXT'))
+            self.assertOk(r.execute_command(
+                'ft.create', 'idx', 'schema', *schema))
+            N = 10
+            for n in range(N):
+                fields = []
+                for i in range(128):
+                    fields.extend(('field_%d' % i, 'hello token_%d' % i))
+                self.assertOk(r.execute_command('ft.add', 'idx', 'doc%d' %n, 1.0, 'fields', *fields))
+            for _ in r.retry_with_rdb_reload():
+                for i in range(128):
+
+                    res = self.search(r,'idx', '@field_%d:token_%d' % (i, i))
+                    self.assertEqual(res[0], N)
+
+                    res = r.execute_command('ft.explain','idx', '@field_%d:token_%d' % (i, i)).strip()
+                    self.assertEqual('@field_%d:token_%d' % (i, i), res)
+
+                    res = self.search(r,'idx', 'hello @field_%d:token_%d' % (i, i))
+                    self.assertEqual(res[0], N)
+
+                res = self.search(r, 'idx', ' '.join(('@field_%d:token_%d' % (i, i) for i in range(128))))
+                self.assertEqual(res[0], N)
+
+                res = self.search(r, 'idx', ' '.join(('token_%d' % (i) for i in range(128))))
+                self.assertEqual(res[0], N)
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/src/pytest/test_wideschema.py
+++ b/src/pytest/test_wideschema.py
@@ -25,13 +25,13 @@ class SearchTestCase(ModuleTestCase('../redisearch.so')):
             for _ in r.retry_with_rdb_reload():
                 for i in range(128):
 
-                    res = self.search(r,'idx', '@field_%d:token_%d' % (i, i))
+                    res = self.search(r,'idx', '@field_%d:token_%d' % (i, i), 'NOCONTENT')
                     self.assertEqual(res[0], N)
 
                     res = r.execute_command('ft.explain','idx', '@field_%d:token_%d' % (i, i)).strip()
                     self.assertEqual('@field_%d:token_%d' % (i, i), res)
 
-                    res = self.search(r,'idx', 'hello @field_%d:token_%d' % (i, i))
+                    res = self.search(r,'idx', 'hello @field_%d:token_%d' % (i, i), 'NOCONTENT')
                     self.assertEqual(res[0], N)
 
                 res = self.search(r, 'idx', ' '.join(('@field_%d:token_%d' % (i, i) for i in range(128))))

--- a/src/query.c
+++ b/src/query.c
@@ -538,13 +538,13 @@ static sds QueryNode_DumpSds(sds s, QueryParseCtx *q, QueryNode *qs, int depth) 
   if (qs->fieldMask && qs->fieldMask != RS_FIELDMASK_ALL && qs->type != QN_NUMERIC &&
       qs->type != QN_GEO && qs->type != QN_IDS) {
     if (!q || !q->sctx->spec) {
-      s = sdscatprintf(s, "@%x", qs->fieldMask);
+      s = sdscatprintf(s, "@%llx", (uint64_t)qs->fieldMask);
     } else {
       s = sdscat(s, "@");
-      uint32_t fm = qs->fieldMask;
+      t_fieldMask fm = qs->fieldMask;
       int i = 0, n = 0;
       while (fm) {
-        uint32_t bit = (fm & 1) << i;
+        t_fieldMask bit = (fm & 1) << i;
         if (bit) {
           char *f = GetFieldNameByBit(q->sctx->spec, bit);
           s = sdscatprintf(s, "%s%s", n ? "|" : "", f ? f : "n/a");

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -90,7 +90,7 @@ typedef struct RSQueryNode {
     QueryPrefixNode pfx;
     QueryWildcardNode wc;
   };
-  uint32_t fieldMask;
+  t_fieldMask fieldMask;
   /* The node type, for resolving the union access */
   QueryNodeType type;
 } QueryNode;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -6,7 +6,7 @@
 
 typedef uint32_t t_docId;
 typedef uint32_t t_offset;
-typedef uint32_t t_fieldMask;
+typedef __uint128_t t_fieldMask;
 
 #define RSFieldMask_Contains(mask, n) (((1 << (n - 1)) & mask) != 0)
 
@@ -15,7 +15,7 @@ struct RSSortingVector;
 #define REDISEARCH_ERR 1
 #define REDISEARCH_OK 0
 
-#define RS_FIELDMASK_ALL 0xFFFFFFFF
+#define RS_FIELDMASK_ALL (((__uint128_t)1 << 127) - (__uint128_t)1 + ((__uint128_t)1 << 127))
 
 /* A payload object is set either by a query expander or by the user, and can be used to process
  * scores. For examples, it can be a feature vector that is then compared to a feature vector

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -210,7 +210,7 @@ typedef struct {
   RSResultType typeMask;
 } RSAggregateResult;
 
-#pragma pack(4)
+#pragma pack(16)
 
 typedef struct RSIndexResult {
 

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -6,6 +6,9 @@
 
 typedef uint32_t t_docId;
 typedef uint32_t t_offset;
+// used to represent the id of a single field.
+// to produce a field mask we calculate 2^fieldId
+typedef uint16_t t_fieldId;
 typedef __uint128_t t_fieldMask;
 
 #define RSFieldMask_Contains(mask, n) (((1 << (n - 1)) & mask) != 0)

--- a/src/rmalloc.h
+++ b/src/rmalloc.h
@@ -37,6 +37,7 @@ static char *rm_strndup(const char *s, size_t n) {
 /* for non redis module targets */
 #define rm_malloc malloc
 #define rm_free free
+#define rm_calloc calloc
 #define rm_realloc realloc
 #define rm_free free
 #define rm_strdup strdup

--- a/src/run_valgrind.sh
+++ b/src/run_valgrind.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+valgrind --tool=memcheck --leak-check=full --show-leak-kinds=definite --suppressions=leakcheck.supp redis-server redis.conf

--- a/src/spec.c
+++ b/src/spec.c
@@ -274,7 +274,7 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, char *
 
       // If we need to store field flags and we have over 32 fields, we need to switch to wide
       // schema encoding
-      if (id > SPEC_WIDEFIELD_THRESHOLD && spec->flags & Index_StoreFieldFlags) {
+      if (id == SPEC_WIDEFIELD_THRESHOLD && spec->flags & Index_StoreFieldFlags) {
         spec->flags |= Index_WideSchema;
       }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -267,7 +267,7 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, char *
     if (spec->fields[spec->numFields].type == F_FULLTEXT &&
         FieldSpec_IsIndexable(&spec->fields[spec->numFields])) {
       // make sure we don't have too many indexable fields
-      if (id > SPEC_MAX_FIELD_ID) {
+      if (id == SPEC_MAX_FIELD_ID) {
         *err = "Too many TEXT fields in schema, the maximum is 32";
         goto failure;
       }

--- a/src/spec.c
+++ b/src/spec.c
@@ -31,7 +31,7 @@ t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len)
   FieldSpec *sp = IndexSpec_GetField(spec, name, len);
   if (!sp) return 0;
 
-  return sp->id;
+  return FIELD_BIT(sp->id);
 }
 
 int IndexSpec_GetFieldSortingIndex(IndexSpec *sp, const char *name, size_t len) {
@@ -39,9 +39,9 @@ int IndexSpec_GetFieldSortingIndex(IndexSpec *sp, const char *name, size_t len) 
   return RSSortingTable_GetFieldIdx(sp->sortables, name);
 }
 
-char *GetFieldNameByBit(IndexSpec *sp, uint32_t id) {
+char *GetFieldNameByBit(IndexSpec *sp, __uint128_t id) {
   for (int i = 0; i < sp->numFields; i++) {
-    if (sp->fields[i].id == id) {
+    if (FIELD_BIT(sp->fields[i].id) == id) {
       return sp->fields[i].name;
     }
   }
@@ -253,7 +253,7 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, char *
     spec->stopwords = DefaultStopWordList();
   }
 
-  uint64_t id = 1;
+  uint64_t id = 0;
   int sortIdx = 0;
 
   int i = schemaOffset + 1;
@@ -272,12 +272,13 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, char *
         goto failure;
       }
 
-      if (id > SPEC_WIDEFIELD_THRESHOLD) {
+      // If we need to store field flags and we have over 32 fields, we need to switch to wide
+      // schema encoding
+      if (id > SPEC_WIDEFIELD_THRESHOLD && spec->flags & Index_StoreFieldFlags) {
         spec->flags |= Index_WideSchema;
       }
 
-      spec->fields[spec->numFields].id = ((t_fieldMask)1) << (id - 1);
-      id++;
+      spec->fields[spec->numFields].id = id++;
     }
     if (FieldSpec_IsSortable(&spec->fields[spec->numFields])) {
       spec->fields[spec->numFields].sortIdx = sortIdx++;
@@ -431,11 +432,7 @@ t_fieldMask IndexSpec_ParseFieldMask(IndexSpec *sp, RedisModuleString **argv, in
     size_t len;
     const char *p = RedisModule_StringPtrLen(argv[i], &len);
 
-    FieldSpec *fs = IndexSpec_GetField(sp, p, len);
-    if (fs != NULL) {
-      LG_DEBUG("Found mask for %s: %llx\n", p, (uint64_t)fs->id);
-      ret |= (fs->id & RS_FIELDMASK_ALL);
-    }
+    ret |= IndexSpec_GetFieldBit(sp, p, len);
   }
 
   return ret;
@@ -508,7 +505,7 @@ int bit(t_fieldMask id) {
 void __fieldSpec_rdbSave(RedisModuleIO *rdb, FieldSpec *f) {
   RedisModule_SaveStringBuffer(rdb, f->name, strlen(f->name) + 1);
 
-  RedisModule_SaveUnsigned(rdb, bit(f->id));
+  RedisModule_SaveUnsigned(rdb, f->id);
   RedisModule_SaveUnsigned(rdb, f->type);
   RedisModule_SaveDouble(rdb, f->weight);
   RedisModule_SaveUnsigned(rdb, f->options);
@@ -519,11 +516,12 @@ void __fieldSpec_rdbLoad(RedisModuleIO *rdb, FieldSpec *f, int encver) {
 
   f->name = RedisModule_LoadStringBuffer(rdb, NULL);
   // the old versions encoded the bit id of the field directly
+  // we convert that to a power of 2
   if (encver < INDEX_MIN_WIDESCHEMA_VERSION) {
-    f->id = RedisModule_LoadUnsigned(rdb);
+    f->id = bit(RedisModule_LoadUnsigned(rdb));
   } else {
     // the new version encodes just the power of 2 of the bit
-    f->id = 1 << RedisModule_LoadUnsigned(rdb);
+    f->id = RedisModule_LoadUnsigned(rdb);
   }
   f->type = RedisModule_LoadUnsigned(rdb);
   f->weight = RedisModule_LoadDouble(rdb);

--- a/src/spec.h
+++ b/src/spec.h
@@ -53,7 +53,7 @@ typedef struct fieldSpec {
   char *name;
   FieldType type;
   double weight;
-  t_fieldMask id;
+  t_fieldId id;
   FieldSpecOptions options;
 
   int sortIdx;
@@ -110,7 +110,7 @@ typedef enum {
 // avove - field ides are encoded as their exponent (bit offset)
 #define INDEX_MIN_WIDESCHEMA_VERSION 7
 
-#define FIELD_BIT(id) (((t_fieldMask)1) << (id - 1));
+#define FIELD_BIT(id) (((t_fieldMask)1) << id)
 
 typedef struct {
   char *name;
@@ -140,7 +140,8 @@ extern RedisModuleType *IndexSpecType;
 */
 FieldSpec *IndexSpec_GetField(IndexSpec *spec, const char *name, size_t len);
 
-char *GetFieldNameByBit(IndexSpec *sp, uint32_t id);
+char *GetFieldNameByBit(IndexSpec *sp, __uint128_t id);
+
 /* Get the field bitmask id of a text field by name. Return 0 if the field is not found or is not a
  * text field */
 t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len);

--- a/src/spec.h
+++ b/src/spec.h
@@ -94,21 +94,22 @@ typedef enum {
   Index_DocIdsOnly = 0x00,
 } IndexFlags;
 
-
-#define INDEX_DEFAULT_FLAGS Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags | Index_StoreByteOffsets
+#define INDEX_DEFAULT_FLAGS \
+  Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags | Index_StoreByteOffsets
 
 #define INDEX_STORAGE_MASK                                                                  \
   (Index_StoreFreqs | Index_StoreFieldFlags | Index_StoreTermOffsets | Index_StoreNumeric | \
    Index_WideSchema)
 #define INDEX_CURRENT_VERSION 7
 #define INDEX_MIN_COMPAT_VERSION 2
-
-#define Index_SupportsHighlight(spec) (((spec)->flags &Index_StoreTermOffsets) &&
-                                       ((spec)->flags &Index_StoreByteOffsets))
-
+// Versions below this always store the frequency
+#define INDEX_MIN_NOFREQ_VERSION 6
 // Versions below this encode field ids as the actual value,
-// avove - field ides are encoded as their exponent (bit offset)
+// above - field ides are encoded as their exponent (bit offset)
 #define INDEX_MIN_WIDESCHEMA_VERSION 7
+
+#define Index_SupportsHighlight(spec) \
+  (((spec)->flags & Index_StoreTermOffsets) && ((spec)->flags & Index_StoreByteOffsets))
 
 #define FIELD_BIT(id) (((t_fieldMask)1) << id)
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -35,7 +35,7 @@ static const char *SpecTypeNames[] = {[F_FULLTEXT] = SPEC_TEXT_STR, [F_NUMERIC] 
 #define INDEX_SPEC_KEY_FMT INDEX_SPEC_KEY_PREFIX "%s"
 
 #define SPEC_MAX_FIELDS 1024
-#define SPEC_MAX_FIELD_ID (t_fieldMask)(1 << 31)
+#define SPEC_MAX_FIELD_ID 128
 
 typedef enum {
   FieldSpec_Sortable = 0x01,
@@ -88,7 +88,8 @@ typedef enum {
   Index_StoreFreqs = 0x010,
   Index_StoreNumeric = 0x020,
   Index_StoreByteOffsets = 0x40,
-  Index_DocIdsOnly = 0x00
+  Index_WideSchema = 0x080,
+  Index_DocIdsOnly = 0x00,
 } IndexFlags;
 
 #define INDEX_DEFAULT_FLAGS \
@@ -103,8 +104,10 @@ typedef enum {
 // Versions below this always store the frequency
 #define INDEX_MIN_NOFREQ_VERSION 6
 
-#define Index_SupportsHighlight(spec) \
-  (((spec)->flags & Index_StoreTermOffsets) && ((spec)->flags & Index_StoreByteOffsets))
+#define Index_SupportsHighlight(spec) (((spec)->flags &Index_StoreTermOffsets) &&
+                                       ((spec)->flags &Index_StoreByteOffsets))
+#define FIELD_BIT(id)(((t_fieldMask) 1) << (id - 1));
+
 
 typedef struct {
   char *name;
@@ -137,7 +140,7 @@ FieldSpec *IndexSpec_GetField(IndexSpec *spec, const char *name, size_t len);
 char *GetFieldNameByBit(IndexSpec *sp, uint32_t id);
 /* Get the field bitmask id of a text field by name. Return 0 if the field is not found or is not a
  * text field */
-uint32_t IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len);
+t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len);
 
 /* Get a sortable field's sort table index by its name. return -1 if the field was not found or is
  * not sortable */

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -718,7 +718,7 @@ int testIndexSpec() {
   ASSERT(s->flags & Index_StoreTermOffsets);
   ASSERT(s->flags & Index_HasCustomStopwords);
 
-  ASSERT(IndexSpec_IsStopWord(s, "hello", 5));
+    ASSERT(IndexSpec_IsStopWord(s, "hello", 5));
   ASSERT(IndexSpec_IsStopWord(s, "world", 5));
   ASSERT(!IndexSpec_IsStopWord(s, "werld", 5));
 
@@ -847,14 +847,16 @@ int testHugeSpec() {
     FAIL("Error parsing spec: %s", err);
   }
   ASSERT(s != NULL);
+
   ASSERT(err == NULL);
-  ASSERT(s->numFields == N)
+  ASSERT(s->numFields == N);
   IndexSpec_Free(s);
 
   // test too big a schema
-  N = 65;
+  N = 300;
   n = 2;
   char *args2[n + N * 3];
+
   fillSchema(args2, N, &n);
 
   err = NULL;
@@ -867,6 +869,7 @@ int testHugeSpec() {
 }
 
 typedef union {
+
   int i;
   float f;
 } u;

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -727,7 +727,7 @@ int testIndexSpec() {
   ASSERT(f->type == F_FULLTEXT);
   ASSERT(strcmp(f->name, body) == 0);
   ASSERT(f->weight == 2.0);
-  ASSERT(f->id == 2);
+  ASSERT_EQUAL(FIELD_BIT(f->id), 2);
   ASSERT(f->options == 0);
   ASSERT(f->sortIdx == -1);
 
@@ -736,7 +736,7 @@ int testIndexSpec() {
   ASSERT(f->type == F_FULLTEXT);
   ASSERT(strcmp(f->name, title) == 0);
   ASSERT(f->weight == 0.1);
-  ASSERT(f->id == 1);
+  ASSERT(FIELD_BIT(f->id) == 1);
   ASSERT(f->options == 0);
   ASSERT(f->sortIdx == -1);
 
@@ -745,7 +745,7 @@ int testIndexSpec() {
   ASSERT(f->type == F_FULLTEXT);
   ASSERT(strcmp(f->name, foo) == 0);
   ASSERT(f->weight == 1);
-  ASSERT(f->id == 4);
+  ASSERT(FIELD_BIT(f->id) == 4);
   ASSERT(f->options == FieldSpec_Sortable);
   ASSERT(f->sortIdx == 0);
 
@@ -754,7 +754,7 @@ int testIndexSpec() {
   ASSERT(f->type == F_NUMERIC);
   ASSERT(strcmp(f->name, bar) == 0);
   ASSERT(f->weight == 0);
-  ASSERT(f->id == 0);
+  ASSERT(FIELD_BIT(f->id) == 1);
   ASSERT(f->options == FieldSpec_Sortable);
   ASSERT(f->sortIdx == 1);
   ASSERT(IndexSpec_GetField(s, "fooz", 4) == NULL)
@@ -764,7 +764,7 @@ int testIndexSpec() {
   ASSERT(f->type == F_FULLTEXT);
   ASSERT(strcmp(f->name, name) == 0);
   ASSERT(f->weight == 1);
-  ASSERT(f->id == 8);
+  ASSERT(FIELD_BIT(f->id) == 8);
   ASSERT(f->options == FieldSpec_NoStemming);
   ASSERT(f->sortIdx == -1);
 

--- a/src/util/block_alloc.h
+++ b/src/util/block_alloc.h
@@ -7,7 +7,7 @@ typedef struct BlkAllocBlock {
   struct BlkAllocBlock *next;
   size_t numUsed;
   size_t capacity;
-  char data[0];
+  char data[0] __attribute__((aligned(16)));;
 } BlkAllocBlock;
 
 typedef struct BlkAlloc {

--- a/src/varint.h
+++ b/src/varint.h
@@ -6,8 +6,6 @@
 #include <stdint.h>
 #include "buffer.h"
 
-size_t varintSize(uint32_t value);
-
 /* Read an encoded integer from the buffer. It is assumed that the buffer will not overflow */
 static inline uint32_t ReadVarint(BufferReader *b) {
 
@@ -23,7 +21,23 @@ static inline uint32_t ReadVarint(BufferReader *b) {
   return val;
 }
 
+static inline __uint128_t ReadVarint128(BufferReader *b) {
+
+  unsigned char c = BUFFER_READ_BYTE(b);
+
+  __uint128_t val = c & 127;
+  while (c >> 7) {
+    ++val;
+    c = BUFFER_READ_BYTE(b);
+    val = (val << 7) | (c & 127);
+  }
+
+  return val;
+}
+
 size_t WriteVarint(uint32_t value, BufferWriter *w);
+
+size_t WriteVarint128(__uint128_t value, BufferWriter *w);
 
 typedef struct {
   Buffer buf;


### PR DESCRIPTION
This PR makes the field mask used in index records 128 bit, with variable encoding. For indexes with less than 32 fiellds there is no change in encoding. 

For indexes with over 32 fields, we added a new "wide" encoding, where up to 128 bits of field bitmask are stored after the record and before the offset vector. 