### PR TITLE
Index stems with a prefix

### DIFF
--- a/docs/Highlight.md
+++ b/docs/Highlight.md
@@ -1,8 +1,9 @@
 # Highlighting API
 
-The highlighting API allows you to have only the relvant (matching)
-portions of document matches returned. This allows users to quickly see how a
-document relates to their query.
+The highlighting API allows you to have only the  relevant portions of document matching a search query returned as a result. 
+This allows users to quickly see how a document relates to their query, with the search terms highlighted, usually in bold letters.
+
+RediSearch implements high performance highlighting an summarization algorithms, with the following API: 
 
 ### Command Syntax
 
@@ -27,25 +28,25 @@ FT.SEARCH ...
     SUMMARIZE [FIELDS {num} {field}] [FRAGS {numFrags}] [LEN {fragLen}] [SEPARATOR {sepStr}]
 ```
 
-Summarization or snippetization will fragment the text into smaller sized
-snippets; each snippet will contain the found term(s) and some additional
+Summarization  will fragment the text into smaller sized snippets; each snippet will contain the found term(s) and some additional
 surrounding context.
 
-Redis Search can perform summarization using the `SUMMARIZE` keyword. If no
-additional arguments are passed, all _returned fields_ are summarized using
-built-in defaults.
+RediSearch can perform summarization using the `SUMMARIZE` keyword. If no additional arguments are passed, 
+all _returned fields_ are summarized using built-in defaults.
 
 The `SUMMARIZE` keyword accepts the following arguments:
 
-* **`FIELDS`** If present, must be the first argument. This should be followed
+* **`FIELDS`**: If present, must be the first argument. This should be followed
     by the number of fields to summarize, which itself is followed by a list of
-    fields. Each field present is summarized. If no `FIELD` directive is passed,
+    fields. Each field present is summarized. If no `FIELDS` directive is passed,
     then *all* fields returned are summarized.
-* **`FRAGS`** How many fragments should be returned. If not specified, a sane
-    default is used.
+
+* **`FRAGS`**: How many fragments should be returned. If not specified, a default of 3 is used.
+
 * **`LEN`** The number of context words each fragment should contain. Context
     words surround the found term. A higher value will return a larger block of
     text.
+
 * **`SEPARATOR`** The string used to divide between individual summary snippets.
     The default is `... ` which is common among search engines; but you may
     override this with any other string if you desire to programmatically divide them
@@ -64,16 +65,16 @@ Highlighting will highlight the found term (and its variants) with a user-define
 tag. This may be used to display the matched text in a different typeface using
 a markup language, or to otherwise make the text appear differently.
 
-Redis Search can perform highlighting using the `HIGHLIGHT` keyword. If no
-additional arguments are passed, all _returned fields_ are highlighted using
-build-in defaults.
+RediSearch can perform highlighting using the `HIGHLIGHT` keyword. If no
+additional arguments are passed, all _returned fields_ are highlighted using built-in defaults.
 
 The `HIGHLIGHT` keyword accepts the following arguments:
 
 * **`FIELDS`** If present, must be the first argument. This should be followed
     by the number of fields to highlight, which itself is followed by a list of
-    fields. Each field present is highlighted. If no `FIELD` directive is passed,
+    fields. Each field present is highlighted. If no `FIELDS` directive is passed,
     then *all* fields returned are highlighted.
+    
 * **`TAGS`** If present, must be followed by two strings; the first is prepended
     to each term match, and the second is appended to it. If no `TAGS` are
     specified, a built-in tag value is appended and prepended.

--- a/docs/Tags.md
+++ b/docs/Tags.md
@@ -18,7 +18,7 @@ we perform are lower-casing (for latin languages only as of now), and whitespace
 modifier (see below) will not return this document.
 
 5. The index is much simpler and more compressed: We do not store frequencies, offset vectors of
-field flags. The index contains only docuent ids encoded as deltas. This means that an entry in a tag index
+field flags. The index contains only document IDs encoded as deltas. This means that an entry in a tag index
 is usually one or two bytes long. This makes them very memory efficient and fast.
 
 6. An unlimited number of tag fields can be created per index, as long as the overall number of fields is under 1024.

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -6,6 +6,7 @@
 #include "default.h"
 #include "../tokenize.h"
 #include "../rmutil/vector.h"
+#include "../stemmer.h"
 
 /******************************************************************************************
  *
@@ -253,14 +254,16 @@ void DefaultStemmerExpand(RSQueryExpanderCtx *ctx, RSToken *token) {
   const sb_symbol *b = (const sb_symbol *)token->str;
   const sb_symbol *stemmed = sb_stemmer_stem(sb, b, token->len);
 
-  if (stemmed && strncasecmp((const char *)stemmed, token->str, token->len)) {
-
+  if (stemmed) {
     int sl = sb_stemmer_length(sb);
-    ctx->ExpandToken(ctx, strndup((const char *)stemmed, sl), sl,
+
+    // Make a copy of the stemmed buffer with the + prefix given to stems
+    char *dup = malloc(sl + 2);
+    dup[0] = STEM_PREFIX;
+    memcpy(dup + 1, stemmed, sl + 1);
+    ctx->ExpandToken(ctx, dup, sl + 1,
                      0x0);  // TODO: Set proper flags here
   }
-
-  // sb_stemmer_delete(sb);
 }
 
 void defaultExpanderFree(void *p) {

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -81,7 +81,9 @@ ForwardIndex *NewForwardIndex(Document *doc, uint32_t idxFlags) {
   BlkAlloc_Init(&idx->entries);
 
   static const KHTableProcs procs = {
-      .Alloc = allocBucketEntry, .Compare = khtCompare, .Hash = khtHash,
+      .Alloc = allocBucketEntry,
+      .Compare = khtCompare,
+      .Hash = khtHash,
   };
 
   size_t termCount = estimtateTermCount(doc);

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -27,7 +27,7 @@ void NumericRangeIterator_OnReopen(RedisModuleKey *k, void *privdata) {
   /* If the key has been deleted we'll get a NULL heere, so we just mark ourselves as EOF
    * We simply abort the root iterator which is either a union of many ranges or a single range
    *
-   * If the numeric range tree has chaned (split, nodes deleted, etc) since we last closed it,
+   * If the numeric range tree has chained (split, nodes deleted, etc) since we last closed it,
    * We cannot continue iterating it, since the underlying pointers might be screwed.
    * For now we will just stop processing this query. This causes the query to return bad results,
    * so in the future we can try an reset the state here

--- a/src/pytest/test_wideschema.py
+++ b/src/pytest/test_wideschema.py
@@ -23,23 +23,29 @@ class SearchTestCase(ModuleTestCase('../redisearch.so')):
                 fields = []
                 for i in range(FIELDS):
                     fields.extend(('field_%d' % i, 'hello token_%d' % i))
-                self.assertOk(r.execute_command('ft.add', 'idx', 'doc%d' %n, 1.0, 'fields', *fields))
+                self.assertOk(r.execute_command('ft.add', 'idx',
+                                                'doc%d' % n, 1.0, 'fields', *fields))
             for _ in r.retry_with_rdb_reload():
                 for i in range(FIELDS):
 
-                    res = self.search(r,'idx', '@field_%d:token_%d' % (i, i), 'NOCONTENT')
+                    res = self.search(
+                        r, 'idx', '@field_%d:token_%d' % (i, i), 'NOCONTENT')
                     self.assertEqual(res[0], N)
 
-                    res = r.execute_command('ft.explain','idx', '@field_%d:token_%d' % (i, i)).strip()
+                    res = r.execute_command(
+                        'ft.explain', 'idx', '@field_%d:token_%d' % (i, i), 'VERBATIM').strip()
                     self.assertEqual('@field_%d:token_%d' % (i, i), res)
 
-                    res = self.search(r,'idx', 'hello @field_%d:token_%d' % (i, i), 'NOCONTENT')
+                    res = self.search(
+                        r, 'idx', 'hello @field_%d:token_%d' % (i, i), 'NOCONTENT')
                     self.assertEqual(res[0], N)
 
-                res = self.search(r, 'idx', ' '.join(('@field_%d:token_%d' % (i, i) for i in range(FIELDS))))
+                res = self.search(r, 'idx', ' '.join(
+                    ('@field_%d:token_%d' % (i, i) for i in range(FIELDS))))
                 self.assertEqual(res[0], N)
 
-                res = self.search(r, 'idx', ' '.join(('token_%d' % (i) for i in range(FIELDS))))
+                res = self.search(r, 'idx', ' '.join(
+                    ('token_%d' % (i) for i in range(FIELDS))))
                 self.assertEqual(res[0], N)
 
 if __name__ == '__main__':

--- a/src/stemmer.h
+++ b/src/stemmer.h
@@ -5,6 +5,8 @@
 typedef enum { SnowballStemmer } StemmerType;
 
 #define DEFAULT_LANGUAGE "english"
+#define STEM_PREFIX '+'
+#define STEMMER_EXPANDER_NAME "stem"
 
 /* Abstract "interface" for a pluggable stemmer, ensuring we can use multiple
  * stemmer libs */
@@ -19,13 +21,11 @@ Stemmer *NewStemmer(StemmerType type, const char *language);
 /* check if a language is supported by our stemmers */
 int IsSupportedLanguage(const char *language, size_t len);
 
-#define STEMMER_EXPANDER_NAME "stem"
 /* Get a stemmer expander instance for registering it */
 void RegisterStemmerExpander();
 
 /* Snoball Stemmer wrapper implementation */
-const char *__sbstemmer_Stem(void *ctx, const char *word, size_t len,
-                             size_t *outlen);
+const char *__sbstemmer_Stem(void *ctx, const char *word, size_t len, size_t *outlen);
 void __sbstemmer_Free(Stemmer *s);
 Stemmer *__newSnowballStemmer(const char *language);
 

--- a/src/tests/test_stemmer.c
+++ b/src/tests/test_stemmer.c
@@ -12,7 +12,7 @@ int testStemmer() {
   size_t sl;
   const char *stem = s->Stem(s->ctx, "arbitrary", (size_t)strlen("arbitrary"), &sl);
   ASSERT(stem != NULL)
-  ASSERT(!strcasecmp(stem, "arbitrari"));
+  ASSERT(!strcasecmp(stem, "+arbitrari"));
   ASSERT(sl == strlen(stem));
   printf("stem: %s\n", stem);
 
@@ -34,8 +34,8 @@ int testTokenize() {
   const char *expectedToks[] = {"hello", "world", "worlds", "going", "wazz", "up", "שלום"};
   const char *expectedStems[] = {NULL /*hello*/,
                                  NULL /*world/*/,
-                                 "world" /*worlds*/,
-                                 "go" /*going*/,
+                                 "+world" /*worlds*/,
+                                 "+go" /*going*/,
                                  NULL /*wazz*/,
                                  NULL /*up*/,
                                  NULL /*שלום*/};

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -108,7 +108,7 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
     if (!(ctx->options & TOKENIZE_NOSTEM) && self->stemmer && normLen >= MIN_STEM_CANDIDATE_LEN) {
       size_t sl;
       const char *stem = self->stemmer->Stem(self->stemmer->ctx, tok, normLen, &sl);
-      if (stem && strncmp(stem, tok, normLen)) {
+      if (stem) {
         t->stem = stem;
         t->stemLen = sl;
       }


### PR DESCRIPTION
 so that searching for a word that's both a stem and a valid term with VERBATIM - will not return documents not containing the verbatim term. 

For example, if we index two documents, one with the term "going" and one with the term "go". 
Before this PR, searching for "go" verbatim, will return the doc containing "going". 

After this PR this won't happen. 

This is because we now use two separate indexes for the term and the stem even if they are identical. we prepend a `+` to the stem. So "going" would get encoded into two indexes: `going` and `+go`. But `go` will get encoded only into `go`. Thus in verbatim mode, we search only for `go`, but in expanded mode we search for `go OR +go`. 