### PR TITLE
Unignore /debian dir in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 !**/*.mak
 !/cndict
 /site
+!/debian/*
 
 src/dep/snowball/libstemmer/mkinc.mak


### PR DESCRIPTION
This would help when packaging this for Debian - currently any changes I
make to the debian/ directly are not immediately visible due to the
default ignore rule. Applying this would mean even less diff between
upstream and the Debian version.