### PR TITLE
Inherit CFLAGS & LDFLAGS from outside environment.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ ifeq ($(DEBUG), 1)
 endif
 
 # Default CFLAGS
-CFLAGS= -Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-result -fPIC \
+CFLAGS += -Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-result -fPIC \
  	-D_GNU_SOURCE -std=gnu99 -I"$(shell pwd)" -DREDIS_MODULE_TARGET \
 	-DREDISMODULE_EXPERIMENTAL_API 
 CFLAGS += $(DEBUGFLAGS)
@@ -123,7 +123,7 @@ $(MODULE_ARTIFACT): $(shell rm -f module.o)
 $(MODULE_ARTIFACT): $(MODULE) version.h
 	@# Just to make sure old versions of the modules are deleted
 	rm -f module.so
-	$(LD) -o $@ $(MODULE) $(SHOBJ_LDFLAGS) -lc -lm
+	$(CC) -o $@ $(MODULE) $(SHOBJ_LDFLAGS) -lc -lm $(LDFLAGS)
 
 # Build a stand-alone static library without the module entry point.
 # This is used to include the module's functionality in other modules


### PR DESCRIPTION
In Debian we use the dpkg-buildflags mechanism to control
enabling/disabling of hardening-related buildflags such as relro, PIE
etc.

However, the current Makefile currently ignores those for CFLAGS and
then ignored them when linking.