### PR TITLE
Dedupes

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -199,7 +199,7 @@ typedef struct RSAddDocumentCtx {
  *
  * When done, call AddDocumentCtx_Free
  */
-RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *base);
+RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *base, const char **err);
 
 /**
  * At this point the context will take over from the caller, and handle sending

--- a/src/module.c
+++ b/src/module.c
@@ -150,7 +150,12 @@ static int doAddDocument(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   LG_DEBUG("Adding doc %s with %d fields\n", RedisModule_StringPtrLen(doc.docKey, NULL),
            doc.numFields);
-  RSAddDocumentCtx *aCtx = NewAddDocumentCtx(sp, &doc);
+  const char *err;
+  RSAddDocumentCtx *aCtx = NewAddDocumentCtx(sp, &doc, &err);
+  if (aCtx == NULL) {
+    Document_FreeDetached(&doc, ctx);
+    return RedisModule_ReplyWithError(ctx, err);
+  }
 
   // in partial mode
   uint32_t options = 0;
@@ -659,7 +664,14 @@ static int doAddHashCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   LG_DEBUG("Adding doc %s with %d fields\n", RedisModule_StringPtrLen(doc.docKey, NULL),
            doc.numFields);
-  RSAddDocumentCtx *aCtx = NewAddDocumentCtx(sp, &doc);
+
+  const char *err;
+  RSAddDocumentCtx *aCtx = NewAddDocumentCtx(sp, &doc, &err);
+  if (aCtx == NULL) {
+    Document_FreeDetached(&doc, ctx);
+    return RedisModule_ReplyWithError(ctx, err);
+  }
+
   if (!isBlockable) {
     aCtx->stateFlags |= ACTX_F_NOBLOCK;
   }

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -1550,6 +1550,11 @@ class SearchTestCase(ModuleTestCase('../redisearch.so')):
                 self.cmd('FT.ADD', 'idx', 'doc2', 1.0, 'REPLACE', 'PARTIAL', 'FIELDS', 'num', 42, 'num', 32)
 
 
+    def testDuplicateSpec(self):
+        with self.assertResponseError():
+            self.cmd('FT.CREATE', 'idx', 'SCHEMA', 'f1', 'text', 'n1', 'numeric', 'f1', 'text')
+
+
 def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
     from itertools import izip_longest

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -985,22 +985,6 @@ class SearchTestCase(ModuleTestCase('../redisearch.so')):
             self.assertEqual(2, len(res))
             self.assertEqual(1, res[0])
 
-    def testDuplicateEntry(self):
-
-        with self.redis() as r:
-            r.flushdb()
-            self.assertOk(r.execute_command(
-                'ft.create', 'idx', 'schema', 'title', 'text', 'score', 'numeric'))
-            for i in xrange(100):
-                self.assertOk(r.execute_command('ft.add', 'idx', 'doc%d' % i, 1, 'fields',
-                                                'title', 'hello kitty', 'score', i, 'score', i, 'SCORE', i))
-
-            for _ in r.retry_with_rdb_reload():
-                res = r.execute_command('ft.search', 'idx', 'hello kitty @score:[0 100]', 'return', '1', 'score', 'limit', '0', '1')
-                self.assertEqual([100L, 'doc99', ['score', '99']], res)
-
-
-
     def testNumericRange(self):
 
         with self.redis() as r:

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -1508,6 +1508,48 @@ class SearchTestCase(ModuleTestCase('../redisearch.so')):
         with self.assertResponseError():
             self.cmd('FT.CREATE', 'idx2', 'schema', 'txt', 'text')
 
+    def testDuplicateNonspecFields(self):
+        self.cmd('FT.CREATE', 'idx', 'schema', 'txt', 'text')
+        self.cmd('FT.ADD', 'idx', 'doc', 1.0, 'fields',
+            'f1', 'f1val', 'f1', 'f1val2', 'F1', 'f1Val3')
+
+        res = self.cmd('ft.get', 'idx', 'doc')
+        res = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+        self.assertTrue(res['f1'] in ('f1val', 'f1val2'))
+        self.assertEqual('f1Val3', res['F1'])
+
+    def testDuplicateFields(self):
+        self.cmd('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'num', 'NUMERIC', 'SORTABLE')
+        for _ in self.retry_with_reload():
+            # Ensure the index assignment is correct after an rdb load
+            with self.assertResponseError():
+                self.cmd('FT.ADD', 'idx', 'doc', 1.0, 'FIELDS',
+                        'txt', 'foo', 'txt', 'bar', 'txt', 'baz')
+
+            # Try add hash
+            self.cmd('HMSET', 'newDoc', 'txt', 'foo', 'Txt', 'bar', 'txT', 'baz')
+            # Get the actual value:
+
+            from redis import ResponseError
+            caught = False
+            try:
+                self.cmd('FT.ADDHASH', 'idx', 'newDoc', 1.0)
+            except ResponseError as err:
+                caught = True
+                self.assertTrue('twice' in err.message)
+            self.assertTrue(caught)
+
+            # Try with REPLACE
+            with self.assertResponseError():
+                self.cmd('FT.ADD', 'idx', 'doc2', 1.0, 'REPLACE', 'FIELDS',
+                    'txt', 'foo', 'txt', 'bar')
+
+            # With replace partial
+            self.cmd('FT.ADD', 'idx', 'doc2', 1.0, 'REPLACE', 'PARTIAL', 'FIELDS', 'num', 42)
+            with self.assertResponseError():
+                self.cmd('FT.ADD', 'idx', 'doc2', 1.0, 'REPLACE', 'PARTIAL', 'FIELDS', 'num', 42, 'num', 32)
+
+
 def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
     from itertools import izip_longest

--- a/src/spec.c
+++ b/src/spec.c
@@ -277,6 +277,8 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, char *
   while (i < argc && spec->numFields < SPEC_MAX_FIELDS) {
 
     FieldSpec *fs = &spec->fields[spec->numFields++];
+    fs->index = spec->numFields - 1;
+
     if (!__parseFieldSpec(argv, &i, argc, fs, err)) {
       if (!*err) {
         *err = "Could not parse field spec";
@@ -645,6 +647,8 @@ void *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver) {
   for (int i = 0; i < sp->numFields; i++) {
 
     __fieldSpec_rdbLoad(rdb, &sp->fields[i], encver);
+    sp->fields[i].index = i;
+
     /* keep track of sorting indexes to rebuild the table */
     if (sp->fields[i].sortIdx > maxSortIdx) {
       maxSortIdx = sp->fields[i].sortIdx;

--- a/src/spec.c
+++ b/src/spec.c
@@ -309,6 +309,11 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, char *
 
       goto failure;
     }
+
+    if (IndexSpec_GetField(spec, fs->name, strlen(fs->name)) != fs) {
+      *err = "Duplicate field in schema";
+      goto failure;
+    }
   }
 
   /* If we have sortable fields, create a sorting lookup table */

--- a/src/spec.h
+++ b/src/spec.h
@@ -82,6 +82,11 @@ typedef struct fieldSpec {
 
   int sortIdx;
 
+  /**
+   * Unique field index. Each field has a unique index regardless of its type
+   */
+  uint16_t index;
+
   union {
     TextFieldOptions textOpts;
     TagFieldOptions tagOpts;
@@ -176,6 +181,14 @@ extern RedisModuleType *IndexSpecType;
  * Return the field spec if found, NULL if not
  */
 FieldSpec *IndexSpec_GetField(IndexSpec *spec, const char *name, size_t len);
+
+/**
+ * This "ID" type is independent of the field mask, and is used to distinguish
+ * between one field and another field. For now, the ID is the position in
+ * the array of fields - a detail we'll try to hide.
+ */
+typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
+#define FIELDSPEC_INVALID_ID UINT16_MAX
 
 char *GetFieldNameByBit(IndexSpec *sp, t_fieldMask id);
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -126,6 +126,13 @@ typedef enum {
   Index_DocIdsOnly = 0x00,
 } IndexFlags;
 
+/**
+ * This "ID" type is independent of the field mask, and is used to distinguish
+ * between one field and another field. For now, the ID is the position in
+ * the array of fields - a detail we'll try to hide.
+ */
+typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
+
 #define INDEX_DEFAULT_FLAGS \
   Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags | Index_StoreByteOffsets
 
@@ -181,14 +188,6 @@ extern RedisModuleType *IndexSpecType;
  * Return the field spec if found, NULL if not
  */
 FieldSpec *IndexSpec_GetField(IndexSpec *spec, const char *name, size_t len);
-
-/**
- * This "ID" type is independent of the field mask, and is used to distinguish
- * between one field and another field. For now, the ID is the position in
- * the array of fields - a detail we'll try to hide.
- */
-typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
-#define FIELDSPEC_INVALID_ID UINT16_MAX
 
 char *GetFieldNameByBit(IndexSpec *sp, t_fieldMask id);
 


### PR DESCRIPTION
This PR comprises two high level changes

- Disallow duplicate definition of fields in schema
- Disallow specifying duplicate indexable/sortable fields when adding a document.

Valgrinded, tested, etc.