### PR TITLE
Fix NOSTOPWORDS

### DIFF
--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -331,6 +331,23 @@ class SearchTestCase(ModuleTestCase('../redisearch.so')):
         self.assertEqual(0, r1[0])
         self.assertEqual(1, r2[0])
 
+
+    def testNoStopwords(self):
+        # This test taken from Java's test suite
+        self.cmd('ft.create', 'idx', 'schema', 'title', 'text')
+        for i in range(100):
+            self.cmd('ft.add', 'idx', 'doc{}'.format(i), 1.0, 'fields',
+                'title', 'hello world' if i % 2 == 0 else 'hello worlds')
+
+        res = self.cmd('ft.search', 'idx', 'hello a world', 'NOCONTENT')
+        self.assertEqual(100, res[0])
+
+        res = self.cmd('ft.search', 'idx', 'hello a world', 'VERBATIM', 'NOCONTENT')
+        self.assertEqual(50, res[0])
+
+        res = self.cmd('ft.search', 'idx', 'hello a world', 'NOSTOPWORDS')
+        self.assertEqual(0, res[0])
+
     def testOptional(self):
         with self.redis() as r:
             r.flushdb()

--- a/src/query.c
+++ b/src/query.c
@@ -641,10 +641,13 @@ QueryParseCtx *NewQueryParseCtx(RSSearchRequest *req) {
   ctx->ok = 1;
   ctx->root = NULL;
   ctx->sctx = req->sctx;
-
-  ctx->stopwords = (ctx->sctx && ctx->sctx->spec && ctx->sctx->spec->stopwords)
-                       ? ctx->sctx->spec->stopwords
-                       : DefaultStopWordList();
+  if (req->flags & Search_NoStopwords) {
+    ctx->stopwords = EmptyStopWordList();
+  } else {
+    ctx->stopwords = (ctx->sctx && ctx->sctx->spec && ctx->sctx->spec->stopwords)
+                         ? ctx->sctx->spec->stopwords
+                         : DefaultStopWordList();
+  }
   ctx->language = req->language ? req->language : DEFAULT_LANGUAGE;
   ctx->tokenId = 1;
   ctx->errorMsg = NULL;

--- a/src/search_request.c
+++ b/src/search_request.c
@@ -41,7 +41,7 @@ RSSearchRequest *ParseRequest(RedisSearchCtx *ctx, RedisModuleString **argv, int
   if (RMUtil_ArgExists("VERBATIM", argv, argc, 3)) req->flags |= Search_Verbatim;
 
   // Parse NOSTOPWORDS argument
-  if (RMUtil_ArgExists("NOSTOPWORDS", argv, argc, 3)) req->flags |= Search_NoStopwrods;
+  if (RMUtil_ArgExists("NOSTOPWORDS", argv, argc, 3)) req->flags |= Search_NoStopwords;
 
   if (RMUtil_ArgExists("INORDER", argv, argc, 3)) {
     req->flags |= Search_InOrder;

--- a/src/search_request.h
+++ b/src/search_request.h
@@ -11,7 +11,7 @@
 typedef enum {
   Search_NoContent = 0x01,
   Search_Verbatim = 0x02,
-  Search_NoStopwrods = 0x04,
+  Search_NoStopwords = 0x04,
 
   Search_WithScores = 0x08,
   Search_WithPayloads = 0x10,

--- a/src/stopwords.c
+++ b/src/stopwords.c
@@ -12,6 +12,7 @@ typedef struct StopWordList {
 } StopWordList;
 
 StopWordList *__default_stopwords = NULL;
+StopWordList *__empty_stopwords = NULL;
 
 StopWordList *DefaultStopWordList() {
   if (__default_stopwords == NULL) {
@@ -19,6 +20,13 @@ StopWordList *DefaultStopWordList() {
                                               sizeof(DEFAULT_STOPWORDS) / sizeof(const char *) - 1);
   }
   return __default_stopwords;
+}
+
+StopWordList *EmptyStopWordList() {
+  if (__empty_stopwords == NULL) {
+    __empty_stopwords = NewStopWordList(NULL, 0);
+  }
+  return __empty_stopwords;
 }
 
 /* Check if a stopword list contains a term. The term must be already lowercased */

--- a/src/stopwords.h
+++ b/src/stopwords.h
@@ -19,6 +19,7 @@ struct StopWordList;
 int StopWordList_Contains(struct StopWordList *sl, const char *term, size_t len);
 
 struct StopWordList *DefaultStopWordList();
+struct StopWordList *EmptyStopWordList();
 
 /* Create a new stopword list from a list of redis strings */
 struct StopWordList *NewStopWordList(RedisModuleString **strs, size_t len);


### PR DESCRIPTION
The `NOSTOPWORDS` option wasn't being honored. The empty stopword list
is now used whenever NOSTOPWORDS is detected, as this will abstract this
option from the rest of the code.