### PR TITLE
Please make the build reproducible

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ CC_SOURCES += $(wildcard $(SOURCEDIR)/dep/thpool/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/dep/cndict/*.c)
 
 # Convert all sources to .o files
-CC_OBJECTS = $(patsubst %.c, %.o, $(CC_SOURCES) )
+CC_OBJECTS = $(sort $(patsubst %.c, %.o, $(CC_SOURCES) ))
 
 # .d files for each c file. These make sure that changing a header file
 # will also change the dependent .c files of it

--- a/src/dep/friso/Makefile.RediSearch
+++ b/src/dep/friso/Makefile.RediSearch
@@ -1,6 +1,6 @@
 SOURCEDIR = .
 CC_SOURCES = $(wildcard $(SOURCEDIR)/*.c)
-CC_OBJECTS = $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o , $(CC_SOURCES))
+CC_OBJECTS = $(sort $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o , $(CC_SOURCES)))
 
 .SUFFIXES: .c .cc .o
 

--- a/src/dep/libnu/Makefile
+++ b/src/dep/libnu/Makefile
@@ -12,7 +12,7 @@ endif
 
 SOURCEDIR = .
 CC_SOURCES = $(wildcard $(SOURCEDIR)/*.c)
-CC_OBJECTS = $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o, $(CC_SOURCES))
+CC_OBJECTS = $(sort $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o, $(CC_SOURCES)))
 
 .SUFFIXES: .c .cc .o
 

--- a/src/dep/triemap/Makefile
+++ b/src/dep/triemap/Makefile
@@ -6,7 +6,7 @@ CFLAGS ?= -W -fno-common -g -ggdb -fPIC -std=gnu99 -O3
 
 SOURCEDIR = .
 CC_SOURCES = $(wildcard $(SOURCEDIR)/*.c)
-CC_OBJECTS = $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o, $(CC_SOURCES))
+CC_OBJECTS = $(sort $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o, $(CC_SOURCES)))
 
 .SUFFIXES: .c .cc .o
 

--- a/src/dep/triemap/test/Makefile
+++ b/src/dep/triemap/test/Makefile
@@ -6,7 +6,7 @@ CFLAGS ?= -fno-common -g -ggdb -fPIC -std=gnu99 -O3
 LDFLAGS ?= -lm
 SOURCEDIR = .
 CC_SOURCES = $(SOURCEDIR)/crc16.c
-CC_OBJECTS = $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o, $(CC_SOURCES))
+CC_OBJECTS = $(sort $(patsubst $(SOURCEDIR)/%.c, $(SOURCEDIR)/%.o, $(CC_SOURCES)))
 
 .SUFFIXES: .c .cc .o
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that redisearch could not be built reproducibly. This is because
it links (etc.) in filesystem ordering which is non-determinstic.

Adding some $(sort ...) calls fixes this for me. You can test this
by using our "disorderfs" tool to mangle the directory ordering.

 [0] https://reproducible-builds.org/