### PR TITLE
Allow to disable partial return timeout

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -54,5 +54,21 @@ int ReadConfig(RedisModuleString **argv, int argc, const char **err) {
     RMUtil_ParseArgsAfter("FRISOINI", argv, argc, "c", &RSGlobalConfig.frisoIni);
   }
 
+  int onTmoIndex = RMUtil_ArgIndex("ON_TIMEOUT", argv, argc);
+  if (onTmoIndex >= 0) {
+    if (onTmoIndex >= argc - 1) {
+      *err = "Invalid ON_TIMEOUT value";
+      return REDISMODULE_ERR;
+    }
+    if (RMUtil_StringEqualsCaseC(argv[onTmoIndex + 1], "RETURN")) {
+      RSGlobalConfig.timeoutPolicy = TimeoutPolicy_Return;
+    } else if (RMUtil_StringEqualsCaseC(argv[onTmoIndex + 1], "FAIL")) {
+      RSGlobalConfig.timeoutPolicy = TimeoutPolicy_Fail;
+    } else {
+      *err = "Invalid ON_TIMEOUT value";
+      return REDISMODULE_ERR;
+    }
+  }
+
   return REDISMODULE_OK;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,12 @@
 
 #include "redismodule.h"
 
+typedef enum {
+  TimeoutPolicy_Default = 0,  // Defer to global config
+  TimeoutPolicy_Return,       // Return what we have on timeout
+  TimeoutPolicy_Fail          // Just fail without returning anything
+} RSTimeoutPolicy;
+
 /* RSConfig is a global configuration struct for the module, it can be included from each file, and
  * is initialized with user config options during module statrtup */
 typedef struct {
@@ -24,6 +30,8 @@ typedef struct {
   // The maximal amount of time a single query can take before timing out, in milliseconds.
   // 0 means unlimited
   long long queryTimeoutMS;
+
+  RSTimeoutPolicy timeoutPolicy;
 } RSConfig;
 
 // global config extern reference
@@ -34,10 +42,10 @@ extern RSConfig RSGlobalConfig;
 int ReadConfig(RedisModuleString **argv, int argc, const char **err);
 
 // default configuration
-#define RS_DEFAULT_CONFIG                                                    \
-  (RSConfig) {                                                               \
-    .concurrentMode = 1, .extLoad = NULL, .enableGC = 1, .minTermPrefix = 2, \
-    .maxPrefixExpansions = 200, .queryTimeoutMS = 500,                       \
+#define RS_DEFAULT_CONFIG                                                                    \
+  (RSConfig) {                                                                               \
+    .concurrentMode = 1, .extLoad = NULL, .enableGC = 1, .minTermPrefix = 2,                 \
+    .maxPrefixExpansions = 200, .queryTimeoutMS = 500, .timeoutPolicy = TimeoutPolicy_Return \
   }
 ;
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -132,6 +132,9 @@ noret:
 // EOF - no results from this processor
 #define RS_RESULT_EOF 2
 
+// STOP - Abort processing immediately!
+#define RS_RESULT_STOP -1
+
 /* Context for a single result processor, including global shared state, upstream processor and
  * private data */
 typedef struct {

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -4,6 +4,7 @@
 #include <stopwords.h>
 #include <redisearch.h>
 #include <sortable.h>
+#include "config.h"
 
 typedef enum {
   // No summaries
@@ -109,26 +110,29 @@ typedef struct {
   /* Does any stage in the query plan beyond the fiters nees the index results? Only scoring
    * functions need them, so for aggregate queries it makes our lives simpler to not assign it */
   int needIndexResult;
-
+  long long timeoutMS;
+  RSTimeoutPolicy timeoutPolicy;
   FieldList fields;
 } RSSearchOptions;
 
-#define RS_DEFAULT_SEARCHOPTS          \
-  ((RSSearchOptions){                  \
-      .stopwords = NULL,               \
-      .language = NULL,                \
-      .payload = NULL,                 \
-      .fieldMask = RS_FIELDMASK_ALL,   \
-      .flags = RS_DEFAULT_QUERY_FLAGS, \
-      .slop = -1,                      \
-      .concurrentMode = 1,             \
-      .sortBy = NULL,                  \
-      .offset = 0,                     \
-      .num = 10,                       \
-      .expander = NULL,                \
-      .scorer = NULL,                  \
-      .needIndexResult = 0,            \
-      .fields = (FieldList){},         \
+#define RS_DEFAULT_SEARCHOPTS                 \
+  ((RSSearchOptions){                         \
+      .stopwords = NULL,                      \
+      .language = NULL,                       \
+      .payload = NULL,                        \
+      .fieldMask = RS_FIELDMASK_ALL,          \
+      .flags = RS_DEFAULT_QUERY_FLAGS,        \
+      .slop = -1,                             \
+      .concurrentMode = 1,                    \
+      .sortBy = NULL,                         \
+      .offset = 0,                            \
+      .num = 10,                              \
+      .expander = NULL,                       \
+      .scorer = NULL,                         \
+      .needIndexResult = 0,                   \
+      .timeoutMS = 0,                         \
+      .timeoutPolicy = TimeoutPolicy_Default, \
+      .fields = (FieldList){},                \
   })
 
 #endif


### PR DESCRIPTION
`ON_TIMEOUT [RETURN|FAIL]` can be set at the module level. When set, the
module will try to refrain from delivering partial results to the user
in case a query times out.

This also introduces the framework to allow independent query-level
timeout policies and intervals, but we need to add that to the command
parser as well.

It shouldn't be a big deal to add to aggregations and search, but I'm unsure what will happen with the command parser for those.