### PR TITLE
Reducers for HLL

### DIFF
--- a/src/aggregate/reducer.c
+++ b/src/aggregate/reducer.c
@@ -143,6 +143,24 @@ static Reducer *NewRandomSampleArgs(RedisSearchCtx *ctx, RSValue **args, size_t 
   return NewRandomSample(ctx, size, property, alias);
 }
 
+static Reducer *NewHllArgs(RedisSearchCtx *ctx, RSValue **args, size_t argc, const char *alias,
+                           char **err) {
+  if (argc != 1 || !RSValue_IsString(args[0])) {
+    SET_ERR(err, "Invalid arguments for HLL");
+    return NULL;
+  }
+  return NewHLL(ctx, alias, RSKEY(RSValue_StringPtrLen(args[0], NULL)));
+}
+
+static Reducer *NewHllSumArgs(RedisSearchCtx *ctx, RSValue **args, size_t argc, const char *alias,
+                              char **err) {
+  if (argc != 1 || !RSValue_IsString(args[0])) {
+    SET_ERR(err, "Invalid arguments for HLL_SUM");
+    return NULL;
+  }
+  return NewHLLSum(ctx, alias, RSKEY(RSValue_StringPtrLen(args[0], NULL)));
+}
+
 typedef Reducer *(*ReducerFactory)(RedisSearchCtx *ctx, RSValue **args, size_t argc,
                                    const char *alias, char **err);
 
@@ -163,6 +181,8 @@ static struct {
     {"stddev", NewStddevArgs, RSValue_Number},
     {"first_value", NewFirstValueArgs, RSValue_String},
     {"random_sample", NewRandomSampleArgs, RSValue_Array},
+    {"hll", NewHllArgs, RSValue_String},
+    {"hll_sum", NewHllSumArgs, RSValue_Number},
 
     {NULL, NULL},
 };

--- a/src/aggregate/reducer.h
+++ b/src/aggregate/reducer.h
@@ -45,6 +45,15 @@ static inline void Reducer_GenericFree(Reducer *r) {
   free(r);
 }
 
+/**
+ * Exactly like GenericFree, but doesn't free private data.
+ */
+static inline void Reducer_GenericFreeWithStaticPrivdata(Reducer *r) {
+  BlkAlloc_FreeAll(&r->ctx.alloc, NULL, 0, 0);
+  free(r->alias);
+  free(r);
+}
+
 static Reducer *NewReducer(RedisSearchCtx *ctx, void *privdata) {
   Reducer *r = malloc(sizeof(*r));
   r->ctx.ctx = ctx;
@@ -87,5 +96,7 @@ RSValueType GetReducerType(const char *name);
 Reducer *NewFirstValue(RedisSearchCtx *ctx, const char *key, const char *sortKey, int asc,
                        const char *alias);
 Reducer *NewRandomSample(RedisSearchCtx *sctx, int size, const char *property, const char *alias);
+Reducer *NewHLL(RedisSearchCtx *ctx, const char *alias, const char *key);
+Reducer *NewHLLSum(RedisSearchCtx *ctx, const char *alias, const char *key);
 
 #endif


### PR DESCRIPTION
This adds reducers for:

- `HLL`: Returning the approximate number of distinct elements as an
  opaque HLL
- `HLL_SUM` - Return the number of distinct elements from one or more
  HLLs.