### PR TITLE
64bit ids (WIP)

### DIFF
--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -412,8 +412,7 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
 
   BufferWriter bw = NewBufferWriter(blk->data);
 
-  //  printf("Writing docId %d, delta %d, flags %x\n", docId, docId - idx->lastId,
-  //  (int)idx->flags);
+  // printf("Writing docId %llu, delta %llu, flags %x\n", docId, delta, (int)idx->flags);
   size_t ret = encoder(&bw, delta, entry);
 
   idx->lastId = docId;
@@ -693,7 +692,8 @@ int IR_Read(void *ctx, RSIndexResult **e) {
     int rv = ir->decoder(&ir->br, ir->decoderCtx, ir->record);
 
     // We write the docid as a 32 bit number when decoding it with qint.
-    ir->lastId = (*(uint32_t *)&ir->record->docId) += ir->lastId;
+    uint32_t delta = *(uint32_t *)&ir->record->docId;
+    ir->lastId = ir->record->docId = delta + ir->lastId;
 
     // The decoder also acts as a filter. A zero return value means that the
     // current record should not be processed.

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -101,7 +101,7 @@ void IndexReader_OnReopen(RedisModuleKey *k, void *privdata);
 
 /* An index encoder is a callback that writes records to the index. It accepts a pre-calculated
  * delta for encoding */
-typedef size_t (*IndexEncoder)(BufferWriter *bw, t_docId delta, RSIndexResult *record);
+typedef size_t (*IndexEncoder)(BufferWriter *bw, uint32_t delta, RSIndexResult *record);
 
 /* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
  */
@@ -149,7 +149,7 @@ int IR_HasNext(void *ctx);
 
 /* Skip to a specific docId in a reader,using the skip index, and read the entry
  * there */
-int IR_SkipTo(void *ctx, uint32_t docId, RSIndexResult **hit);
+int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit);
 
 RSIndexResult *IR_Current(void *ctx);
 

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef uint32_t t_docId;
-typedef uint32_t t_offset;
+typedef uint64_t t_docId;
+typedef uint64_t t_offset;
 // used to represent the id of a single field.
 // to produce a field mask we calculate 2^fieldId
 typedef uint16_t t_fieldId;

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -931,7 +931,7 @@ int testIndexFlags() {
   ASSERT(w->flags == flags);
   size_t sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   // printf("written %zd bytes. Offset=%zd\n", sz, h.vw->buf.offset);
-  ASSERT_EQUAL(16, sz);
+  ASSERT_EQUAL(15, sz);
   InvertedIndex_Free(w);
 
   flags &= ~Index_StoreTermOffsets;
@@ -948,8 +948,7 @@ int testIndexFlags() {
   ASSERT((w->flags & Index_WideSchema));
   enc = InvertedIndex_GetEncoder(w->flags);
   h.fieldMask = 0xffffffffffff;
-
-  ASSERT_EQUAL(22, InvertedIndex_WriteForwardIndexEntry(w, enc, &h));
+  ASSERT_EQUAL(21, InvertedIndex_WriteForwardIndexEntry(w, enc, &h));
   InvertedIndex_Free(w);
 
   flags |= Index_WideSchema;
@@ -958,7 +957,7 @@ int testIndexFlags() {
   enc = InvertedIndex_GetEncoder(w->flags);
   h.fieldMask = 0xffffffffffff;
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  ASSERT_EQUAL(22, sz);
+  ASSERT_EQUAL(21, sz);
   InvertedIndex_Free(w);
 
   flags &= Index_StoreFreqs;
@@ -967,7 +966,7 @@ int testIndexFlags() {
   ASSERT(!(w->flags & Index_StoreFieldFlags));
   enc = InvertedIndex_GetEncoder(w->flags);
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  ASSERT_EQUAL(4, sz);
+  ASSERT_EQUAL(3, sz);
   InvertedIndex_Free(w);
 
   flags |= Index_StoreFieldFlags | Index_WideSchema;
@@ -977,7 +976,7 @@ int testIndexFlags() {
   enc = InvertedIndex_GetEncoder(w->flags);
   h.fieldMask = 0xffffffffffff;
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  ASSERT_EQUAL(11, sz);
+  ASSERT_EQUAL(10, sz);
   InvertedIndex_Free(w);
 
   VVW_Free(h.vw);
@@ -1142,7 +1141,6 @@ int testVarintFieldMask() {
   RETURN_TEST_SUCCESS;
 }
 TEST_MAIN({
-
   // LOGGING_INIT(L_INFO);
   RMUTil_InitAlloc();
 

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -1180,6 +1180,7 @@ int testDeltaSplits() {
 
   IR_Free(ir);
   InvertedIndex_Free(idx);
+  RETURN_TEST_SUCCESS;
 }
 
 TEST_MAIN({

--- a/src/tests/test_tag_index.c
+++ b/src/tests/test_tag_index.c
@@ -23,7 +23,7 @@ int testTagIndexCreate() {
   }
 
   ASSERT_EQUAL(idx->values->cardinality, array_len(v));
-  ASSERT_EQUAL(305496, totalSZ);
+  ASSERT_EQUAL(300000, totalSZ);
 
   IndexIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, NULL, NULL, NULL, 1);
   ASSERT(it != NULL);


### PR DESCRIPTION
I need to write tests for this. I tried removing the block's `lastId` field but it became a bit annoying. We do *sort* of use it for binary search. It's possible to remove it, but it's not super trivial. I did find some places where we could optimize the binary search even more, but I don't want to mess with that code now unless we have to.