### PR TITLE
Compact doc table

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -33,6 +33,16 @@ int ReadConfig(RedisModuleString **argv, int argc, const char **err) {
     }
   }
 
+  /* Read the minum query prefix allowed */
+  if (argc >= 2 && RMUtil_ArgIndex("MAXDOCTABLESIZE", argv, argc) >= 0) {
+    RMUtil_ParseArgsAfter("MAXDOCTABLESIZE", argv, argc, "l", &RSGlobalConfig.maxDocTableSize);
+    if (RSGlobalConfig.maxDocTableSize <= 0 ||
+        RSGlobalConfig.minTermPrefix >= DEFAULT_MAX_DOC_TABLE_SIZE) {
+      *err = "Invalid MAXDOCTABLESIZE value";
+      return REDISMODULE_ERR;
+    }
+  }
+
   /* Read the maximum prefix expansions */
   if (argc >= 2 && RMUtil_ArgIndex("MAXEXPANSIONS", argv, argc) >= 0) {
     RMUtil_ParseArgsAfter("MAXEXPANSIONS", argv, argc, "l", &RSGlobalConfig.maxPrefixExpansions);

--- a/src/config.h
+++ b/src/config.h
@@ -49,7 +49,9 @@ typedef struct {
   // longer ones
   long long cursorMaxIdle;
 
-  RSTimeoutPolicy timeoutPolicy;
+  long long timeoutPolicy;
+
+  size_t maxDocTableSize;
 } RSConfig;
 
 // global config extern reference
@@ -59,12 +61,14 @@ extern RSConfig RSGlobalConfig;
  * REDISMODULE_ERR and sets an error message if something is invalid */
 int ReadConfig(RedisModuleString **argv, int argc, const char **err);
 
+#define DEFAULT_MAX_DOC_TABLE_SIZE 1000000
+
 // default configuration
-#define RS_DEFAULT_CONFIG                                                                     \
-  (RSConfig) {                                                                                \
-    .concurrentMode = 1, .extLoad = NULL, .enableGC = 1, .minTermPrefix = 2,                  \
-    .maxPrefixExpansions = 200, .queryTimeoutMS = 500, .timeoutPolicy = TimeoutPolicy_Return, \
-    .cursorReadSize = 1000, .cursorMaxIdle = 300000                                           \
+#define RS_DEFAULT_CONFIG                                                                          \
+  (RSConfig) {                                                                                     \
+    .concurrentMode = 1, .extLoad = NULL, .enableGC = 1, .minTermPrefix = 2,                       \
+    .maxPrefixExpansions = 200, .queryTimeoutMS = 500, .timeoutPolicy = TimeoutPolicy_Return,      \
+    .cursorReadSize = 1000, .cursorMaxIdle = 300000, .maxDocTableSize = DEFAULT_MAX_DOC_TABLE_SIZE \
   }
 ;
 

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -66,20 +66,29 @@ void DocIdMap_Free(DocIdMap *m);
  * NOTE: Currently there is no deduplication on the table so we do not prevent dual insertion of
  * the
  * same key. This may result in document duplication in results  */
+
+typedef struct {
+  uint16_t len;
+  uint16_t cap;
+  RSDocumentMetadata docs[];
+} DMDArray;
+
 typedef struct {
   size_t size;
+  // the maximum size this table is allowed to grow to
+  size_t maxSize;
   t_docId maxDocId;
   size_t cap;
   size_t memsize;
   size_t sortablesSize;
 
-  RSDocumentMetadata *docs;
+  DMDArray **buckets;
   DocIdMap dim;
 
 } DocTable;
 
 /* Creates a new DocTable with a given capacity */
-DocTable NewDocTable(size_t cap);
+DocTable NewDocTable(size_t cap, size_t maxSize);
 
 /* Get the metadata for a doc Id from the DocTable.
  *  If docId is not inside the table, we return NULL */

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -84,28 +84,29 @@ typedef struct {
 
 } DocTable;
 
-#define DOC_TABLE_MAX_SIZE 1000000
+#define DOCTABLE_MAX_SIZE 1000000
 
 /* increasing the ref count of the given dmd */
-#define DocTable_IncreaseDmdRefCount(md) if(md) ++md->ref_count;
+#define DocTable_IncreaseDmdRefCount(md) \
+  if (md) ++md->ref_count;
 
-#define DocTable_ForEach(dt, code) \
-  for (size_t i = 1; i < dt->cap; ++i) {\
-    DMDChain *chain = &dt->buckets[i];\
-    if (DMDChain_IsEmpty(chain)) {\
-      continue;\
-    }\
-    RSDocumentMetadata *dmd = chain->first;\
-    while (dmd) {\
-      code;\
-      dmd = dmd->next;\
-    }\
+#define DocTable_ForEach(dt, code)          \
+  for (size_t i = 1; i < dt->cap; ++i) {    \
+    DMDChain *chain = &dt->buckets[i];      \
+    if (DMDChain_IsEmpty(chain)) {          \
+      continue;                             \
+    }                                       \
+    RSDocumentMetadata *dmd = chain->first; \
+    while (dmd) {                           \
+      code;                                 \
+      dmd = dmd->next;                      \
+    }                                       \
   }
 
 /* Creates a new DocTable with a given capacity */
 DocTable NewDocTable(size_t cap, size_t max_size);
 
-#define DocTable_New(cap) NewDocTable(cap, DOC_TABLE_MAX_SIZE)
+#define DocTable_New(cap) NewDocTable(cap, RSGlobalConfig.maxDocTableSize)
 
 /* Get the metadata for a doc Id from the DocTable.
  *  If docId is not inside the table, we return NULL */

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -43,7 +43,9 @@ static inline RedisModuleString *DMD_CreateKeyString(const RSDocumentMetadata *d
 }
 
 /* Map between external id an incremental id */
-typedef struct { TrieMap *tm; } DocIdMap;
+typedef struct {
+  TrieMap *tm;
+} DocIdMap;
 
 DocIdMap NewDocIdMap();
 /* Get docId from a did-map. Returns 0  if the key is not in the map */
@@ -87,7 +89,7 @@ typedef struct {
 #define DOCTABLE_MAX_SIZE 1000000
 
 /* increasing the ref count of the given dmd */
-#define DocTable_IncreaseDmdRefCount(md) \
+#define DMD_Incref(md) \
   if (md) ++md->ref_count;
 
 #define DocTable_ForEach(dt, code)          \
@@ -159,8 +161,15 @@ void DocTable_Free(DocTable *t);
 
 int DocTable_Delete(DocTable *t, RSDocumentKey key);
 
-/* Decrease the ref count and free the given dmd if its ref count reached zero */
-void DocTable_DecreaseDmdRefCount(RSDocumentMetadata *dmd);
+/* don't use this function directly. Use DMD_Decref */
+void DMD_Free(RSDocumentMetadata *);
+
+/* Decrement the refcount of the DMD object, freeing it if we're the last reference */
+static inline void DMD_Decref(RSDocumentMetadata *dmd) {
+  if (dmd && !--dmd->ref_count) {
+    DMD_Free(dmd);
+  }
+}
 
 /* Save the table to RDB. Called from the owning index */
 void DocTable_RdbSave(DocTable *t, RedisModuleIO *rdb);

--- a/src/document.c
+++ b/src/document.c
@@ -522,7 +522,7 @@ int Document_EvalExpression(RedisSearchCtx *sctx, RedisModuleString *key, const 
   SearchResult res = (SearchResult){
       .docId = doc.docId,
       .fields = fm,
-      .md = md,
+      .scorerPrivateData = md,
   };
   // All this is needed to eval the expression
   RSFunctionEvalCtx *fctx = RS_NewFunctionEvalCtx();

--- a/src/pytest/test_doctable.py
+++ b/src/pytest/test_doctable.py
@@ -1,0 +1,36 @@
+from rmtest import ModuleTestCase
+import redis
+import unittest
+from hotels import hotels
+import random
+import time
+
+
+class SearchTestCase(ModuleTestCase('../redisearch.so', module_args=('MAXDOCTABLESIZE', '100'))):
+
+    # mainly this test adding and removing docs while the doc table size is 100
+    # and make sure we are not crashing and not leaking memory (when runs with valgrind).
+    def testDocTable(self):
+        with self.redis() as r:
+            r.flushdb()
+            self.assertOk(r.execute_command(
+                'ft.create', 'idx', 'schema', 'title', 'text', 'body', 'text'))
+            # doc table size is 100 so insearting 1000 docs should gives us 10 docs in each bucket
+            for i in range(1000):
+                self.assertOk(r.execute_command('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
+                                                'title', 'hello world %d' % (i % 100),
+                                                'body', 'lorem ist ipsum'))
+
+            for i in range(100):
+                res = r.execute_command('ft.search', 'idx', 'hello world %d' % i)
+                self.assertEqual(res[0], 10)
+
+            # deleting the first 100 docs
+            for i in range(100):
+                self.assertEqual(r.execute_command('ft.del', 'idx', 'doc%d' % i), 1)
+
+            for i in range(100):
+                res = r.execute_command('ft.search', 'idx', 'hello world %d' % i)
+                self.assertEqual(res[0], 9)
+
+            self.assertOk(r.execute_command('ft.drop', 'idx'))

--- a/src/query_plan.c
+++ b/src/query_plan.c
@@ -118,7 +118,6 @@ static void Query_SerializeResults(QueryPlan *qex, RedisModuleCtx *output) {
 
     if (HAS_TIMEOUT_FAILURE(qex)) {
       RSFieldMap_Free(r.fields, 0);
-      DocTable_FreeDmd(r.md);
       qex->outputFlags |= QP_OUTPUT_FLAG_DONE;
       break;
     }
@@ -137,7 +136,6 @@ static void Query_SerializeResults(QueryPlan *qex, RedisModuleCtx *output) {
 
     // IndexResult_Free(r.indexResult);
     RSFieldMap_Free(r.fields, 0);
-    DocTable_FreeDmd(r.md);
     r.fields = NULL;
 
     if (limit) {

--- a/src/query_plan.c
+++ b/src/query_plan.c
@@ -118,6 +118,7 @@ static void Query_SerializeResults(QueryPlan *qex, RedisModuleCtx *output) {
 
     if (HAS_TIMEOUT_FAILURE(qex)) {
       RSFieldMap_Free(r.fields, 0);
+      DocTable_FreeDmd(r.md);
       qex->outputFlags |= QP_OUTPUT_FLAG_DONE;
       break;
     }
@@ -136,6 +137,7 @@ static void Query_SerializeResults(QueryPlan *qex, RedisModuleCtx *output) {
 
     // IndexResult_Free(r.indexResult);
     RSFieldMap_Free(r.fields, 0);
+    DocTable_FreeDmd(r.md);
     r.fields = NULL;
 
     if (limit) {

--- a/src/query_plan.c
+++ b/src/query_plan.c
@@ -11,9 +11,9 @@
 static size_t serializeResult(QueryPlan *qex, SearchResult *r, RSSearchFlags flags,
                               RedisModuleCtx *ctx) {
   size_t count = 0;
-  if (r->md && !(qex->opts.flags & Search_AggregationQuery)) {
+  if (r->scorerPrivateData && !(qex->opts.flags & Search_AggregationQuery)) {
     size_t klen;
-    const char *k = DMD_KeyPtrLen(r->md, &klen);
+    const char *k = DMD_KeyPtrLen(r->scorerPrivateData, &klen);
     count += 1;
     RedisModule_ReplyWithStringBuffer(ctx, k, klen);
   }
@@ -25,7 +25,7 @@ static size_t serializeResult(QueryPlan *qex, SearchResult *r, RSSearchFlags fla
 
   if (flags & Search_WithPayloads) {
     ++count;
-    const RSPayload *payload = r->md ? r->md->payload : NULL;
+    const RSPayload *payload = r->scorerPrivateData ? r->scorerPrivateData->payload : NULL;
     if (payload) {
       RedisModule_ReplyWithStringBuffer(ctx, payload->data, payload->len);
     } else {
@@ -35,7 +35,7 @@ static size_t serializeResult(QueryPlan *qex, SearchResult *r, RSSearchFlags fla
 
   if (flags & Search_WithSortKeys) {
     ++count;
-    const RSValue *sortkey = RSSortingVector_Get(r->sv, qex->opts.sortBy);
+    const RSValue *sortkey = RSSortingVector_Get(r->sorterPrivateData, qex->opts.sortBy);
     if (sortkey) {
       switch (sortkey->t) {
         case RSValue_Number:

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -457,10 +457,16 @@ int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments) {
 
     DocTable *dt = &ctx->spec->docs;
 
-    // for (size_t i = 1; i < dt->size; i++) {
-    //   const RSDocumentMetadata *dmd = dt->docs + i;
-    //   Redis_DeleteKey(ctx->redisCtx, DMD_CreateKeyString(dmd, ctx->redisCtx));
-    // }
+    for (size_t i = 1; i < dt->cap; ++i) {
+      DMDArray *arr = dt->buckets[i];
+      if (!arr) {
+        continue;
+      }
+      for (int j = 0; j < arr->len; ++j) {
+        const RSDocumentMetadata *dmd = &arr->docs[j];
+        Redis_DeleteKey(ctx->redisCtx, DMD_CreateKeyString(dmd, ctx->redisCtx));
+      }
+    }
   }
 
   // Delete any dangling term keys

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -457,10 +457,10 @@ int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments) {
 
     DocTable *dt = &ctx->spec->docs;
 
-    for (size_t i = 1; i < dt->size; i++) {
-      const RSDocumentMetadata *dmd = dt->docs + i;
-      Redis_DeleteKey(ctx->redisCtx, DMD_CreateKeyString(dmd, ctx->redisCtx));
-    }
+    // for (size_t i = 1; i < dt->size; i++) {
+    //   const RSDocumentMetadata *dmd = dt->docs + i;
+    //   Redis_DeleteKey(ctx->redisCtx, DMD_CreateKeyString(dmd, ctx->redisCtx));
+    // }
   }
 
   // Delete any dangling term keys

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -453,18 +453,7 @@ int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments) {
   if (deleteDocuments) {
 
     DocTable *dt = &ctx->spec->docs;
-
-    for (size_t i = 1; i < dt->cap; ++i) {
-      DMDChain *chain = &dt->buckets[i];
-      if (DMDChain_IsEmpty(chain)) {
-        continue;
-      }
-      RSDocumentMetadata *dmd = chain->first;
-      while (dmd) {
-        Redis_DeleteKey(ctx->redisCtx, DMD_CreateKeyString(dmd, ctx->redisCtx));
-        dmd = dmd->next;
-      }
-    }
+    DocTable_ForEach(dt, Redis_DeleteKey(ctx->redisCtx, DMD_CreateKeyString(dmd, ctx->redisCtx)));
   }
 
   // Delete any dangling term keys

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -74,6 +74,8 @@ typedef struct {
   struct RSSortingVector *sortVector;
   /* Offsets of all terms in the document (in bytes). Used by highlighter */
   struct RSByteOffsets *byteOffsets;
+
+  t_docId id;
 } RSDocumentMetadata;
 
 /* Forward declaration of the opaque query object */

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -52,7 +52,7 @@ typedef enum {
  *
  * Flags is not currently used, but should be used in the future to mark documents as deleted, etc.
  */
-typedef struct {
+typedef struct RSDocumentMetadata_s {
   /* The actual key of the document, not the internal incremental id */
   char *keyPtr;
 
@@ -76,6 +76,11 @@ typedef struct {
   struct RSByteOffsets *byteOffsets;
 
   t_docId id;
+
+  uint32_t ref_count;
+
+  struct RSDocumentMetadata_s *next;
+  struct RSDocumentMetadata_s *prev;
 } RSDocumentMetadata;
 
 /* Forward declaration of the opaque query object */
@@ -202,9 +207,7 @@ typedef struct {
 
 } RSVirtualRecord;
 
-typedef struct {
-  double value;
-} RSNumericRecord;
+typedef struct { double value; } RSNumericRecord;
 
 typedef enum {
   RSResultType_Union = 0x1,

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -14,9 +14,7 @@
 ResultProcessor *NewResultProcessor(ResultProcessor *upstream, void *privdata) {
   ResultProcessor *p = calloc(1, sizeof(ResultProcessor));
   p->ctx = (ResultProcessorCtx){
-      .privdata = privdata,
-      .upstream = upstream,
-      .qxc = upstream ? upstream->ctx.qxc : NULL,
+      .privdata = privdata, .upstream = upstream, .qxc = upstream ? upstream->ctx.qxc : NULL,
   };
 
   return p;
@@ -140,6 +138,7 @@ int baseResultProcessor_Next(ResultProcessorCtx *ctx, SearchResult *res) {
   res->indexResult = r;  // q->opts.needIndexResult ? r : NULL;
 
   res->score = 0;
+  ++dmd->ref_count;  // we increase the refcount so the dmd will not be freed till we done with it
   res->sv = dmd->sortVector;
   res->md = dmd;
   if (res->fields != NULL) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -296,7 +296,7 @@ int sorter_Yield(struct sorterCtx *sc, SearchResult *r) {
   if (sc->pq->count > 0 && (!sc->size || sc->offset++ < sc->size)) {
     SearchResult *sr = mmh_pop_max(sc->pq);
     *r = *sr;
-    DocTable_DecreaseDmdRefCount(r->scorerPrivateData);
+    DMD_Decref(r->scorerPrivateData);
     free(sr);
     return RS_RESULT_OK;
   }
@@ -349,7 +349,7 @@ int sorter_Next(ResultProcessorCtx *ctx, SearchResult *r) {
 
     // copy the index result to make it thread safe - but only if it is pushed to the heap
     h->indexResult = NULL;
-    DocTable_IncreaseDmdRefCount(h->scorerPrivateData);
+    DMD_Incref(h->scorerPrivateData);
     mmh_insert(sc->pq, h);
     sc->pooledResult = NULL;
     if (h->score < ctx->qxc->minScore) {
@@ -371,7 +371,7 @@ int sorter_Next(ResultProcessorCtx *ctx, SearchResult *r) {
       h->indexResult = NULL;
       sc->pooledResult = mmh_pop_min(sc->pq);
       SearchResult_FreeInternal(sc->pooledResult);
-      DocTable_IncreaseDmdRefCount(h->scorerPrivateData);
+      DMD_Incref(h->scorerPrivateData);
       mmh_insert(sc->pq, h);
     } else {
       // The current should not enter the pool, so just leave it as is

--- a/src/spec.c
+++ b/src/spec.c
@@ -562,7 +562,7 @@ IndexSpec *NewIndexSpec(const char *name, size_t numFields) {
   sp->numFields = 0;
   sp->flags = INDEX_DEFAULT_FLAGS;
   sp->name = rm_strdup(name);
-  sp->docs = NewDocTable(100);
+  sp->docs = DocTable_New(100);
   sp->stopwords = DefaultStopWordList();
   sp->terms = NewTrie();
   sp->gc = NULL;
@@ -695,7 +695,7 @@ void *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver) {
   IndexSpec *sp = rm_malloc(sizeof(IndexSpec));
   sp->sortables = NewSortingTable();
   sp->terms = NULL;
-  sp->docs = NewDocTable(1000);
+  sp->docs = DocTable_New(1000);
   sp->name = RedisModule_LoadStringBuffer(rdb, NULL);
   sp->gc = NULL;
   sp->flags = (IndexFlags)RedisModule_LoadUnsigned(rdb);

--- a/src/spec.c
+++ b/src/spec.c
@@ -562,7 +562,7 @@ IndexSpec *NewIndexSpec(const char *name, size_t numFields) {
   sp->numFields = 0;
   sp->flags = INDEX_DEFAULT_FLAGS;
   sp->name = rm_strdup(name);
-  sp->docs = NewDocTable(100, 1000000);
+  sp->docs = NewDocTable(100);
   sp->stopwords = DefaultStopWordList();
   sp->terms = NewTrie();
   sp->gc = NULL;
@@ -695,7 +695,7 @@ void *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver) {
   IndexSpec *sp = rm_malloc(sizeof(IndexSpec));
   sp->sortables = NewSortingTable();
   sp->terms = NULL;
-  sp->docs = NewDocTable(1000, 1000000);
+  sp->docs = NewDocTable(1000);
   sp->name = RedisModule_LoadStringBuffer(rdb, NULL);
   sp->gc = NULL;
   sp->flags = (IndexFlags)RedisModule_LoadUnsigned(rdb);

--- a/src/spec.c
+++ b/src/spec.c
@@ -562,7 +562,7 @@ IndexSpec *NewIndexSpec(const char *name, size_t numFields) {
   sp->numFields = 0;
   sp->flags = INDEX_DEFAULT_FLAGS;
   sp->name = rm_strdup(name);
-  sp->docs = NewDocTable(100);
+  sp->docs = NewDocTable(100, 1000000);
   sp->stopwords = DefaultStopWordList();
   sp->terms = NewTrie();
   sp->gc = NULL;
@@ -695,7 +695,7 @@ void *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver) {
   IndexSpec *sp = rm_malloc(sizeof(IndexSpec));
   sp->sortables = NewSortingTable();
   sp->terms = NULL;
-  sp->docs = NewDocTable(1000);
+  sp->docs = NewDocTable(1000, 1000000);
   sp->name = RedisModule_LoadStringBuffer(rdb, NULL);
   sp->gc = NULL;
   sp->flags = (IndexFlags)RedisModule_LoadUnsigned(rdb);

--- a/src/spec.h
+++ b/src/spec.h
@@ -32,8 +32,7 @@ typedef enum fieldType { FIELD_FULLTEXT, FIELD_NUMERIC, FIELD_GEO, FIELD_TAG } F
 #define SPEC_SEPARATOR_STR "SEPARATOR"
 
 static const char *SpecTypeNames[] = {[FIELD_FULLTEXT] = SPEC_TEXT_STR,
-                                      [FIELD_NUMERIC] = NUMERIC_STR,
-                                      [FIELD_GEO] = GEO_STR,
+                                      [FIELD_NUMERIC] = NUMERIC_STR, [FIELD_GEO] = GEO_STR,
                                       [FIELD_TAG] = SPEC_TAG_STR};
 
 #define INDEX_SPEC_KEY_PREFIX "idx:"
@@ -143,7 +142,9 @@ typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
   (Index_StoreFreqs | Index_StoreFieldFlags | Index_StoreTermOffsets | Index_StoreNumeric | \
    Index_WideSchema)
 
-#define INDEX_CURRENT_VERSION 11
+#define INDEX_CURRENT_VERSION 12
+// Those versions contains doc table as array, we modified it to be array of linked lists
+#define INDEX_MAX_VERSION_WITH_OLD_DOC_TABLE 11
 #define INDEX_MIN_COMPAT_VERSION 2
 // Versions below this always store the frequency
 #define INDEX_MIN_NOFREQ_VERSION 6

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -987,7 +987,7 @@ int testIndexFlags() {
 int testDocTable() {
 
   char buf[16];
-  DocTable dt = NewDocTable(10, 10);
+  DocTable dt = NewDocTable(10);
   t_docId did = 0;
   int N = 100;
   for (int i = 0; i < N; i++) {
@@ -1002,7 +1002,7 @@ int testDocTable() {
   ASSERT_EQUAL(N, dt.maxDocId);
   ASSERT(dt.cap > dt.size);
 #ifdef __x86_64__
-// ASSERT_EQUAL(7780, (int)dt.memsize); //todo meir : fix it
+  ASSERT_EQUAL(10980, (int)dt.memsize);
 #endif
   for (int i = 0; i < N; i++) {
     sprintf(buf, "doc_%d", i);

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -987,7 +987,7 @@ int testIndexFlags() {
 int testDocTable() {
 
   char buf[16];
-  DocTable dt = NewDocTable(10);
+  DocTable dt = NewDocTable(10,10);
   t_docId did = 0;
   int N = 100;
   for (int i = 0; i < N; i++) {
@@ -1000,7 +1000,6 @@ int testDocTable() {
 
   ASSERT_EQUAL(N + 1, dt.size);
   ASSERT_EQUAL(N, dt.maxDocId);
-  ASSERT(dt.cap > dt.size);
 #ifdef __x86_64__
   ASSERT_EQUAL(10980, (int)dt.memsize);
 #endif

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -987,7 +987,7 @@ int testIndexFlags() {
 int testDocTable() {
 
   char buf[16];
-  DocTable dt = NewDocTable(10);
+  DocTable dt = NewDocTable(10, 10);
   t_docId did = 0;
   int N = 100;
   for (int i = 0; i < N; i++) {
@@ -1002,7 +1002,7 @@ int testDocTable() {
   ASSERT_EQUAL(N, dt.maxDocId);
   ASSERT(dt.cap > dt.size);
 #ifdef __x86_64__
-  ASSERT_EQUAL(7780, (int)dt.memsize);
+// ASSERT_EQUAL(7780, (int)dt.memsize); //todo meir : fix it
 #endif
   for (int i = 0; i < N; i++) {
     sprintf(buf, "doc_%d", i);

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -1015,7 +1015,7 @@ int testDocTable() {
     ASSERT_EQUAL((int)score, i);
 
     RSDocumentMetadata *dmd = DocTable_Get(&dt, i + 1);
-    DocTable_IncreaseDmdRefCount(dmd);
+    DMD_Incref(dmd);
     ASSERT(dmd != NULL);
     ASSERT(dmd->flags & Document_HasPayload);
     ASSERT_STRING_EQ(dmd->keyPtr, (char *)buf);
@@ -1032,7 +1032,7 @@ int testDocTable() {
     int rc = DocTable_Delete(&dt, MakeDocKey(dmd->keyPtr, sdslen(dmd->keyPtr)));
     ASSERT_EQUAL(1, rc);
     ASSERT((int)(dmd->flags & Document_Deleted));
-    DocTable_DecreaseDmdRefCount(dmd);
+    DMD_Decref(dmd);
     dmd = DocTable_Get(&dt, i + 1);
     ASSERT(!dmd);
   }


### PR DESCRIPTION
The doc table is now a arrays of linked lists of dmds.
A new document is added to the tail of the relavent linked list.
The dmds is managed using ref counts to make sure we will not free the dmd when some other
query thread is using it.