### PR TITLE
fixed: redisearch crashes on gc invocation after deleting and recreating an index

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -30,7 +30,8 @@ typedef struct {
 typedef struct GarbageCollectorCtx GarbageCollectorCtx;
 
 /* Create a new garbage collector, with a string for the index name, and initial frequency */
-GarbageCollectorCtx *NewGarbageCollector(const RedisModuleString *k, float initial_hz);
+GarbageCollectorCtx *NewGarbageCollector(const RedisModuleString *k, float initial_hz,
+                                         uint64_t spec_unique_id);
 
 // Start the collector thread
 int GC_Start(GarbageCollectorCtx *ctx);

--- a/src/rmutil/periodic.c
+++ b/src/rmutil/periodic.c
@@ -40,7 +40,9 @@ static void *rmutilTimer_Loop(void *ctx) {
       if (RedisModule_GetThreadSafeContext) rctx = RedisModule_GetThreadSafeContext(NULL);
 
       // call our callback...
-      tm->cb(rctx, tm->privdata);
+      if (!tm->cb(rctx, tm->privdata)) {
+        break;
+      }
 
       // If needed - free the thread safe context.
       // It's up to the user to decide whether automemory is active there

--- a/src/rmutil/periodic.h
+++ b/src/rmutil/periodic.h
@@ -11,7 +11,7 @@ struct RMUtilTimer;
 /* RMutilTimerFunc - callback type for timer tasks. The ctx is a thread-safe redis module context
  * that should be locked/unlocked by the callback when running stuff against redis. privdata is
  * pre-existing private data */
-typedef void (*RMutilTimerFunc)(RedisModuleCtx *ctx, void *privdata);
+typedef int (*RMutilTimerFunc)(RedisModuleCtx *ctx, void *privdata);
 
 typedef void (*RMUtilTimerTerminationFunc)(void *privdata);
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -186,6 +186,8 @@ typedef struct {
 
   SynonymMap *smap;
 
+  uint64_t unique_id;
+
 } IndexSpec;
 
 extern RedisModuleType *IndexSpecType;


### PR DESCRIPTION
When deleting and index, if the gc thread is inside the blocking stage:
if ((rc = pthread_cond_timedwait(&tm->cond, &tm->lock, &timeout)) == ETIMEDOUT) {
then it will get the signal and exist. But if the gc is currently running then it will not get the signal and will keep running.
Now as long as we do not create an index with the same name we are safe, the gc will failed to open it and will do nothing.
The moment we recreate the index, the gc reopen it and start running on garbage …
The more docs we have the greater the probability that we send the signal while the gc is running.

The solution is set a unique id to each index on index creation, when gc iteration starts we check that the unique id match.
If the unique id is not match we just drop the gc thread.