### PR TITLE
see #374, fixed crash when using LOAD after GROUPBY

### DIFF
--- a/src/aggregate/aggregate_plan.c
+++ b/src/aggregate/aggregate_plan.c
@@ -523,6 +523,7 @@ int AggregatePlan_Build(AggregatePlan *plan, CmdArg *cmd, char **err) {
       isLoadAllow = false;
     } else if (!strcasecmp(key, "APPLY")) {
       next = newApplyStepArgs(child, err);
+      isLoadAllow = false;
     } else if (!strcasecmp(key, "LIMIT")) {
       next = newLimit(child, err);
       isLoadAllow = false;

--- a/src/pytest/test_aggregate.py
+++ b/src/pytest/test_aggregate.py
@@ -365,44 +365,34 @@ class AggregateTestCase(BaseModuleTestCase):
                               ['brand', 'mad catz', 'top_item', 'mad catz s.t.r.i.k.e.7 gaming keyboard', 'top_price', '295.95', 'bottom_item', 'madcatz mov4545 xbox replacement breakaway cable', 'bottom_price', '3.49']], res)
 
     def _testLoadAfterGroupBy(self):
-        try:
+        with self.assertResponseError():
             self.cmd('ft.aggregate', 'games', '*',
                      'GROUPBY', 1, '@brand',
                      'LOAD', 1, '@brand')
-        except Exception as e:
-            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
 
     def _testLoadAfterSortBy(self):
-        try:
+        with self.assertResponseError():
             self.cmd('ft.aggregate', 'games', '*',
                      'SORTBY', 1, '@brand',
                      'LOAD', 1, '@brand')
-        except Exception as e:
-            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
 
     def _testLoadAfterApply(self):
-        try:
+        with self.assertResponseError():
             self.cmd('ft.aggregate', 'games', '*',
                      'APPLY', 'timefmt(1517417144)', 'AS', 'dt',
                      'LOAD', 1, '@brand')
-        except Exception as e:
-            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
 
     def _testLoadAfterFilter(self):
-        try:
+        with self.assertResponseError():
             self.cmd('ft.aggregate', 'games', '*',
                      'FILTER', '@count > 5',
                      'LOAD', 1, '@brand')
-        except Exception as e:
-            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
 
     def _testLoadAfterLimit(self):
-        try:
+        with self.assertResponseError():
             self.cmd('ft.aggregate', 'games', '*',
                      'LIMIT', '0', '5',
                      'LOAD', 1, '@brand')
-        except Exception as e:
-            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
 
     def testAll(self):
 

--- a/src/pytest/test_aggregate.py
+++ b/src/pytest/test_aggregate.py
@@ -364,6 +364,46 @@ class AggregateTestCase(BaseModuleTestCase):
                                   'bottom_item', 'beyerdynamic headzone pc gaming digital surround sound system with mmx300 digital headset with microphone', 'bottom_price', '0'],
                               ['brand', 'mad catz', 'top_item', 'mad catz s.t.r.i.k.e.7 gaming keyboard', 'top_price', '295.95', 'bottom_item', 'madcatz mov4545 xbox replacement breakaway cable', 'bottom_price', '3.49']], res)
 
+    def _testLoadAfterGroupBy(self):
+        try:
+            self.cmd('ft.aggregate', 'games', '*',
+                     'GROUPBY', 1, '@brand',
+                     'LOAD', 1, '@brand')
+        except Exception as e:
+            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
+
+    def _testLoadAfterSortBy(self):
+        try:
+            self.cmd('ft.aggregate', 'games', '*',
+                     'SORTBY', 1, '@brand',
+                     'LOAD', 1, '@brand')
+        except Exception as e:
+            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
+
+    def _testLoadAfterApply(self):
+        try:
+            self.cmd('ft.aggregate', 'games', '*',
+                     'APPLY', 'timefmt(1517417144)', 'AS', 'dt',
+                     'LOAD', 1, '@brand')
+        except Exception as e:
+            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
+
+    def _testLoadAfterFilter(self):
+        try:
+            self.cmd('ft.aggregate', 'games', '*',
+                     'FILTER', '@count > 5',
+                     'LOAD', 1, '@brand')
+        except Exception as e:
+            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
+
+    def _testLoadAfterLimit(self):
+        try:
+            self.cmd('ft.aggregate', 'games', '*',
+                     'LIMIT', '0', '5',
+                     'LOAD', 1, '@brand')
+        except Exception as e:
+            self.assertEqual(str(e), 'LOAD can not come after GROUPBY/SORTBY/APPLY/LIMIT/FILTER')
+
     def testAll(self):
 
         for name, f in self.__class__.__dict__.iteritems():


### PR DESCRIPTION
Now user will not be able to use LOAD after GROUPBY/SORTBY/APPLY/LIMIT/FILTER.
Error message will be returned to the user in such case.