### PR TITLE
Don't forget to run RMUtil's own tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ SET(RS_COMMON_FLAGS "${RS_COMMON_FLAGS} -pthread")
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${RS_COMMON_FLAGS} -std=gnu99")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RS_COMMON_FLAGS} -fno-rtti -fno-exceptions")
 
+IF(RS_RUN_TESTS)
+    ENABLE_TESTING()
+ENDIF()
+
 # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
 FOREACH (flags_var_to_scrub
     CMAKE_CXX_FLAGS_RELEASE
@@ -86,7 +90,6 @@ SET_TARGET_PROPERTIES(redisearch PROPERTIES SUFFIX ".so")
 TARGET_LINK_LIBRARIES(redisearchS -lm -lc -ldl)
 
 IF (RS_RUN_TESTS)
-    ENABLE_TESTING()
     ADD_SUBDIRECTORY(src/tests)
     ADD_SUBDIRECTORY(src/pytest)
 ENDIF()

--- a/src/rmutil/CMakeLists.txt
+++ b/src/rmutil/CMakeLists.txt
@@ -8,3 +8,15 @@ ADD_LIBRARY(rmutil OBJECT
     strings.c
     util.c
     vector.c)
+
+FUNCTION(_rmutilTest name)
+    ADD_EXECUTABLE("${name}" "${name}.c" $<TARGET_OBJECTS:rmutil>)
+    ADD_TEST(NAME "${name}" COMMAND "${name}")
+ENDFUNCTION()
+
+FILE(GLOB TEST_SOURCES "test_*.c")
+FOREACH(n ${TEST_SOURCES})
+    GET_FILENAME_COMPONENT(test_name ${n} NAME_WE)
+    _rmutilTest("${test_name}")
+ENDFOREACH()
+

--- a/src/rmutil/CMakeLists.txt
+++ b/src/rmutil/CMakeLists.txt
@@ -11,6 +11,7 @@ ADD_LIBRARY(rmutil OBJECT
 
 FUNCTION(_rmutilTest name)
     ADD_EXECUTABLE("${name}" "${name}.c" $<TARGET_OBJECTS:rmutil>)
+    TARGET_LINK_LIBRARIES(${name} m)
     ADD_TEST(NAME "${name}" COMMAND "${name}")
 ENDFUNCTION()
 

--- a/src/rmutil/periodic.c
+++ b/src/rmutil/periodic.c
@@ -75,7 +75,10 @@ RMUtilTimer *RMUtil_NewPeriodicTimer(RMutilTimerFunc cb, RMUtilTimerTerminationF
                                      void *privdata, struct timespec interval) {
   RMUtilTimer *ret = malloc(sizeof(*ret));
   *ret = (RMUtilTimer){
-      .privdata = privdata, .interval = interval, .cb = cb, .onTerm = onTerm,
+      .privdata = privdata,
+      .interval = interval,
+      .cb = cb,
+      .onTerm = onTerm,
   };
   pthread_cond_init(&ret->cond, NULL);
   pthread_mutex_init(&ret->lock, NULL);

--- a/src/rmutil/test_cmdparse.c
+++ b/src/rmutil/test_cmdparse.c
@@ -50,8 +50,8 @@ int testSchema() {
   ASSERT_STRING_EQ("BAZ", opt.opts[2]);
 
   printf("\n\n");
-  CmdSchemaNode_Free(root);
   CmdSchemaNode_Print(root, 0);
+  CmdSchemaNode_Free(root);
   return 0;
 }
 
@@ -92,7 +92,7 @@ int testTuple() {
   cmd = NULL;
   args = CmdParser_NewArgListV(4, "FOO", "TUP", "2", "hello");
   rc = CmdParser_ParseCmd(sc, &cmd, args, 4, &err, 1);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_ERR, rc);
   ASSERT(cmd == NULL);
   ASSERT(err != NULL);
@@ -103,7 +103,7 @@ int testTuple() {
   cmd = NULL;
   args = CmdParser_NewArgListV(5, "FOO", "TUP", "xx", "hello", "xx");
   rc = CmdParser_ParseCmd(sc, &cmd, args, 5, &err, 1);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_ERR, rc);
   ASSERT(cmd == NULL);
   ASSERT(err != NULL);
@@ -188,7 +188,7 @@ int testPositional() {
   CmdArg *cmd = NULL;
   char *err = NULL;
   int rc = CmdParser_ParseCmd(sc, &cmd, args, 3, &err, 1);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_OK, rc);
   ASSERT(cmd != NULL);
 
@@ -215,7 +215,7 @@ int testFlag() {
   CmdArg *cmd = NULL;
   char *err = NULL;
   int rc = CmdParser_ParseCmd(sc, &cmd, args, 2, &err, 1);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_OK, rc);
   ASSERT(cmd != NULL);
   CmdArg *bar = CmdArg_FirstOf(cmd, "bar");
@@ -242,7 +242,7 @@ int testOption() {
   CmdArg *cmd = NULL;
   char *err = NULL;
   int rc = CmdParser_ParseCmd(sc, &cmd, args, 2, &err, 1);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_OK, rc);
   ASSERT(cmd != NULL);
   CmdArg *barvaz = CmdArg_FirstOf(cmd, "barvaz");
@@ -286,7 +286,7 @@ int testSubSchema() {
   CmdArg *cmd = NULL;
   char *err = NULL;
   int rc = CmdParser_ParseCmd(sc, &cmd, args, 6, &err, 1);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_OK, rc);
   ASSERT(cmd != NULL);
   CmdArg *s = CmdArg_FirstOf(cmd, "sub");
@@ -344,7 +344,7 @@ int testRepeating() {
   CmdArg *cmd = NULL;
   char *err = NULL;
   int rc = CmdParser_ParseCmd(sc, &cmd, args, 9, &err, 1);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_OK, rc);
   ASSERT(cmd != NULL);
   ASSERT(cmd->obj.len == 4);
@@ -409,7 +409,7 @@ int testVariadic() {
   CmdArg *cmd = NULL;
   char *err = NULL;
   int rc = CmdParser_ParseCmd(sc, &cmd, args, 10, &err, 0);
-  printf("%s\n", err);
+  if (err != NULL) printf("%s\n", err);
   ASSERT_EQUAL(CMDPARSE_OK, rc);
   ASSERT(cmd != NULL);
 
@@ -496,7 +496,6 @@ void exampleZadd() {
 }
 
 TEST_MAIN({
-
   exampleZadd();
 
   TESTFUNC(testSchema);
@@ -510,6 +509,5 @@ TEST_MAIN({
   TESTFUNC(testRequired);
   TESTFUNC(testRepeating);
   TESTFUNC(testStrict);
-  TESTFUNC(testVariadic);
-
+  TESTFUNC(testVariadic)
 })

--- a/src/rmutil/test_periodic.c
+++ b/src/rmutil/test_periodic.c
@@ -5,22 +5,22 @@
 #include "assert.h"
 #include "test.h"
 
-void timerCb(RedisModuleCtx *ctx, void *p) {
+int timerCb(RedisModuleCtx *ctx, void *p) {
   int *x = p;
   (*x)++;
+  return 1;
 }
 
 int testPeriodic() {
-  int x = 0;
-  struct RMUtilTimer *tm =
-      RMUtil_NewPeriodicTimer(timerCb, &x, (struct timespec){.tv_sec = 0, .tv_nsec = 10000000});
-
-  sleep(1);
-
-  ASSERT_EQUAL(0, RMUtilTimer_Stop(tm));
+  volatile int x = 0;
+  struct RMUtilTimer *tm = RMUtil_NewPeriodicTimer(
+      timerCb, NULL, (void *)&x, (struct timespec){.tv_sec = 0, .tv_nsec = 10000000});
+  while (!x) {
+    // spin
+  }
+  ASSERT_EQUAL(0, RMUtilTimer_Terminate(tm));
   ASSERT(x > 0);
   ASSERT(x <= 100);
-  RMUtilTimer_Free(tm);
   return 0;
 }
 


### PR DESCRIPTION
Effectively, we maintain rmutil here in RediSearch, so we ought to run
its tests to ensure its stability.