### PR TITLE
Replace (most) instances of string-out pointer with QueryError object

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -29,7 +29,7 @@ typedef struct {
 
 void Aggregate_BuildSchema();
 
-ResultProcessor *Aggregate_DefaultChainBuilder(QueryPlan *plan, void *ctx, char **err);
+ResultProcessor *Aggregate_DefaultChainBuilder(QueryPlan *plan, void *ctx, QueryError *status);
 
 // Don't enable concurrent mode.
 #define AGGREGATE_REQUEST_NO_CONCURRENT 0x01
@@ -51,7 +51,7 @@ typedef struct {
  */
 int AggregateRequest_Start(AggregateRequest *req, RedisSearchCtx *sctx,
                            const AggregateRequestSettings *settings, RedisModuleString **argv,
-                           int argc, char **err);
+                           int argc, QueryError *status);
 void AggregateRequest_Run(AggregateRequest *req, RedisModuleCtx *outCtx);
 void AggregateRequest_Free(AggregateRequest *req);
 
@@ -70,10 +70,10 @@ ResultProcessor *NewGrouperProcessor(Grouper *g, ResultProcessor *upstream);
 void Grouper_AddReducer(Grouper *g, Reducer *r);
 
 ResultProcessor *GetProjector(ResultProcessor *upstream, const char *name, const char *alias,
-                              CmdArg *args, char **err);
+                              CmdArg *args, QueryError *status);
 
 ResultProcessor *NewFilter(RedisSearchCtx *sctx, ResultProcessor *upstream, const char *expr,
-                           size_t len, char **err);
+                           size_t len, QueryError *status);
 
 // Entry points
 void AggregateCommand_ExecAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,

--- a/src/aggregate/aggregate_plan.c
+++ b/src/aggregate/aggregate_plan.c
@@ -528,7 +528,7 @@ int AggregatePlan_Build(AggregatePlan *plan, CmdArg *cmd, char **err) {
       next = newLimit(child, err);
       isLoadAllow = false;
     } else if (!strcasecmp(key, "LOAD")) {
-      if(!isLoadAllow){
+      if (!isLoadAllow) {
         *err = strdup(LOAD_NO_ALLOW_ERROR);
         goto fail;
       }

--- a/src/aggregate/filter.c
+++ b/src/aggregate/filter.c
@@ -3,6 +3,7 @@
 #include <rmutil/cmdparse.h>
 #include <aggregate/expr/expression.h>
 #include <aggregate/functions/function.h>
+#include "aggregate.h"
 
 typedef struct {
   RSExpr *exp;
@@ -44,14 +45,15 @@ int Filter_Next(ResultProcessorCtx *ctx, SearchResult *res) {
 }
 
 ResultProcessor *NewFilter(RedisSearchCtx *sctx, ResultProcessor *upstream, const char *expr,
-                           size_t len, char **err) {
+                           size_t len, QueryError *status) {
 
   FilterCtx *ctx = NewFilterCtx();
   ctx->ctx.sctx = sctx;
   ctx->ctx.sortables = sctx && sctx->spec ? sctx->spec->sortables : NULL;
   ctx->ctx.fctx = RS_NewFunctionEvalCtx();
-  ctx->exp = RSExpr_Parse(expr, len, err);
+  ctx->exp = RSExpr_Parse(expr, len, &status->detail);
   if (!ctx->exp) {
+    QueryError_MaybeSetCode(status, QUERY_EEXPR);
     free(ctx);
     return NULL;
   }

--- a/src/aggregate/project.h
+++ b/src/aggregate/project.h
@@ -3,7 +3,8 @@
 
 #include <result_processor.h>
 #include <aggregate/expr/expression.h>
+#include "query_error.h"
 
 ResultProcessor *NewProjector(RedisSearchCtx *sctx, ResultProcessor *upstream, const char *alias,
-                              const char *expr, size_t len, char **err);
+                              const char *expr, size_t len, QueryError *status);
 #endif

--- a/src/aggregate/projector.c
+++ b/src/aggregate/projector.c
@@ -51,13 +51,14 @@ int Projector_Next(ResultProcessorCtx *ctx, SearchResult *res) {
 }
 
 ResultProcessor *NewProjector(RedisSearchCtx *sctx, ResultProcessor *upstream, const char *alias,
-                              const char *expr, size_t len, char **err) {
+                              const char *expr, size_t len, QueryError *status) {
 
   ProjectorCtx *ctx = NewProjectorCtx(alias);
   ctx->ctx.sctx = sctx;
   ctx->ctx.sortables = sctx && sctx->spec ? sctx->spec->sortables : NULL;
   ctx->ctx.fctx = RS_NewFunctionEvalCtx();
-  ctx->exp = RSExpr_Parse(expr, len, err);
+  ctx->exp = RSExpr_Parse(expr, len, &status->detail);
+  QueryError_MaybeSetCode(status, QUERY_EEXPR);
   if (!ctx->exp) {
     free(ctx);
     return NULL;

--- a/src/aggregate/reducer.h
+++ b/src/aggregate/reducer.h
@@ -6,6 +6,7 @@
 #include <dep/triemap/triemap.h>
 #include <rmutil/cmdparse.h>
 #include <util/block_alloc.h>
+#include "query_error.h"
 
 /* Maximum possible value to random sample group size */
 #define MAX_SAMPLE_SIZE 1000
@@ -91,7 +92,7 @@ Reducer *NewCountDistinctish(RedisSearchCtx *, const char *, const char *);
 Reducer *NewQuantile(RedisSearchCtx *, const char *, const char *, double, size_t);
 Reducer *NewStddev(RedisSearchCtx *, const char *, const char *);
 Reducer *GetReducer(RedisSearchCtx *ctx, const char *name, const char *alias, RSValue **args,
-                    size_t argc, char **err);
+                    size_t argc, QueryError *err);
 RSValueType GetReducerType(const char *name);
 Reducer *NewFirstValue(RedisSearchCtx *ctx, const char *key, const char *sortKey, int asc,
                        const char *alias);

--- a/src/document.c
+++ b/src/document.c
@@ -583,7 +583,9 @@ int Document_EvalExpression(RedisSearchCtx *sctx, RedisModuleString *key, const 
 
   // create a mock search result
   SearchResult res = (SearchResult){
-      .docId = doc.docId, .fields = fm, .scorerPrivateData = md,
+      .docId = doc.docId,
+      .fields = fm,
+      .scorerPrivateData = md,
   };
   // All this is needed to eval the expression
   RSFunctionEvalCtx *fctx = RS_NewFunctionEvalCtx();

--- a/src/module.c
+++ b/src/module.c
@@ -532,9 +532,9 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     const char *operation = RedisModule_StringPtrLen(argv[nextPos + 1], NULL);
     const char *dictName = RedisModule_StringPtrLen(argv[nextPos + 2], NULL);
     if (strcasecmp(operation, "INCLUDE") == 0) {
-      includeDict = array_append(includeDict, (char*)dictName);
+      includeDict = array_append(includeDict, (char *)dictName);
     } else if (strcasecmp(operation, "EXCLUDE") == 0) {
-      excludeDict = array_append(excludeDict, (char*)dictName);
+      excludeDict = array_append(excludeDict, (char *)dictName);
     } else {
       RedisModule_ReplyWithError(ctx, "bad format, exlude/include operation was not given");
       goto end;
@@ -576,14 +576,14 @@ int QueryExplainCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
 
-  char *err = NULL;
-
-  RSSearchRequest *req = ParseRequest(sctx, argv, argc, &err);
+  QueryError status = {0};
+  RSSearchRequest *req = ParseRequest(sctx, argv, argc, &status);
   if (req == NULL) {
-    RedisModule_Log(ctx, "warning", "Error parsing request: %s", err);
+    const char *errstr = QueryError_GetError(&status);
+    RedisModule_Log(ctx, "warning", "Error parsing request: %s", errstr);
     SearchCtx_Free(sctx);
-    RedisModule_ReplyWithError(ctx, err);
-    ERR_FREE(err);
+    RedisModule_ReplyWithError(ctx, errstr);
+    QueryError_ClearError(&status);
     return REDISMODULE_OK;
   }
 
@@ -593,12 +593,12 @@ int QueryExplainCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return RedisModule_ReplyWithError(ctx, "Error parsing query");
   }
 
-  if (!Query_Parse(q, &err)) {
-
-    if (err) {
-      RedisModule_Log(ctx, "debug", "Error parsing query: %s", err);
-      RedisModule_ReplyWithError(ctx, err);
-      ERR_FREE(err);
+  if (!Query_Parse(q, &status.detail)) {
+    // TODO: Use proper 'status' for this...
+    if (status.detail) {
+      RedisModule_Log(ctx, "debug", "Error parsing query: %s", status.detail);
+      RedisModule_ReplyWithError(ctx, status.detail);
+      ERR_FREE(status.detail);
     } else {
       /* Simulate an empty response - this means an empty query */
       RedisModule_ReplyWithArray(ctx, 1);
@@ -903,31 +903,30 @@ void _SearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     return;
   }
 
-  char *err = NULL;
+  QueryError status = {0};
   RSSearchRequest *req = NULL;
   QueryParseCtx *q = NULL;
   QueryPlan *plan = NULL;
 
-  req = ParseRequest(sctx, argv, argc, &err);
+  req = ParseRequest(sctx, argv, argc, &status);
   if (req == NULL) {
-    RedisModule_Log(ctx, "warning", "Error parsing request: %s", err);
-    RedisModule_ReplyWithError(ctx, err ? err : "Error parsing request");
-
+    RedisModule_Log(ctx, "warning", "Error parsing request: %s", status.detail);
+    RedisModule_ReplyWithError(ctx, QueryError_GetError(&status));
     goto end;
   }
 
-  q = SearchRequest_ParseQuery(sctx, req, &err);
-  if (!q && err) {
-    RedisModule_Log(ctx, "warning", "Error parsing query: %s", err);
-    RedisModule_ReplyWithError(ctx, err);
+  q = SearchRequest_ParseQuery(sctx, req, &status);
+  if (!q && status.code != QUERY_OK) {
+    RedisModule_Log(ctx, "warning", "Error parsing query: %s", QueryError_GetError(&status));
+    RedisModule_ReplyWithError(ctx, QueryError_GetError(&status));
     goto end;
   }
 
-  plan = SearchRequest_BuildPlan(sctx, req, q, &err);
+  plan = SearchRequest_BuildPlan(sctx, req, q, &status);
   if (!plan) {
-    if (err) {
-      RedisModule_Log(ctx, "debug", "Error parsing query: %s", err);
-      RedisModule_ReplyWithError(ctx, err);
+    if (QueryError_HasError(&status) && status.code != QUERY_ENORESULTS) {
+      RedisModule_Log(ctx, "debug", "Error parsing query: %s", QueryError_GetError(&status));
+      RedisModule_ReplyWithError(ctx, QueryError_GetError(&status));
     } else {
       /* Simulate an empty response - this means an empty query */
       RedisModule_ReplyWithArray(ctx, 1);
@@ -937,12 +936,12 @@ void _SearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   }
 
   QueryPlan_Run(plan, ctx);
-  if (err) {
-    RedisModule_ReplyWithError(ctx, err);
+  if (QueryError_HasError(&status)) {
+    RedisModule_ReplyWithError(ctx, QueryError_GetError(&status));
   }
 
 end:
-  ERR_FREE(err);
+  QueryError_ClearError(&status);
 
   if (plan) QueryPlan_Free(plan);
   if (sctx) SearchCtx_Free(sctx);

--- a/src/query.h
+++ b/src/query.h
@@ -18,6 +18,7 @@
 #include "rmutil/sds.h"
 #include "concurrent_ctx.h"
 #include "search_options.h"
+#include "query_error.h"
 
 /* A QueryParseCtx represents the parse tree and execution plan for a single
  * search QueryParseCtx */
@@ -55,6 +56,7 @@ typedef struct {
   int tokenId;
   DocTable *docTable;
   RSSearchOptions *opts;
+  QueryError *status;
 } QueryEvalCtx;
 
 /* Evaluate a QueryParseCtx stage and prepare it for execution. As execution is lazy

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -1,0 +1,112 @@
+#ifndef QUERY_ERROR_H
+#define QUERY_ERROR_H
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define QUERY_XERRS(X)                                                   \
+  X(QUERY_EGENERIC, "Generic error evaluating the query")                \
+  X(QUERY_ESYNTAX, "Parsing/Syntax error for query string")              \
+  X(QUERY_EPARSEARGS, "Error parsing query/aggregation arguments")       \
+  X(QUERY_EEXPR, "Parsing/Evaluating dynamic expression failed")         \
+  X(QUERY_EKEYWORD, "Could not handle query keyword")                    \
+  X(QUERY_ENORESULTS, "Query matches no results")                        \
+  X(QUERY_EBADATTR, "Attribute not supported for term")                  \
+  X(QUERY_EINVAL, "Could not validate the query nodes (bad attribute?)") \
+  X(QUERY_EBUILDPLAN, "Could not build plan from query")                 \
+  X(QUERY_ECONSTRUCT_PIPELINE, "Could not construct query pipeline")     \
+  X(QUERY_ENOREDUCER, "Missing reducer")                                 \
+  X(QUERY_EREDUCER_GENERIC, "Generic reducer error")                     \
+  X(QUERY_EAGGPLAN, "Could not plan aggregation request")                \
+  X(QUERY_ECURSORALLOC, "Could not allocate a cursor")                   \
+  X(QUERY_EREDUCERINIT, "Could not initialize reducer")
+
+typedef enum {
+  QUERY_OK = 0,
+
+#define X(N, msg) N,
+  QUERY_XERRS(X)
+#undef X
+} QueryErrorCode;
+
+typedef struct {
+  QueryErrorCode code;
+  char *detail;
+} QueryError;
+
+static inline const char *QueryError_Strerror(QueryErrorCode code) {
+  if (code == QUERY_OK) {
+    return "Success (not an error)";
+  }
+#define X(N, M)    \
+  if (code == N) { \
+    return M;      \
+  }
+  QUERY_XERRS(X)
+#undef X
+  return "Unknown status code";
+}
+
+static inline void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *err) {
+  if (status->code != QUERY_OK) {
+    return;
+  }
+  status->code = code;
+  if (err) {
+    status->detail = strdup(err);
+  } else {
+    status->detail = strdup(QueryError_Strerror(code));
+  }
+}
+
+static inline void QueryError_SetErrorFmt(QueryError *status, QueryErrorCode code, const char *fmt,
+                                          ...) {
+  if (status->code != QUERY_OK) {
+    return;
+  }
+  va_list ap;
+  va_start(ap, fmt);
+  vasprintf(&status->detail, fmt, ap);
+  va_end(ap);
+}
+
+static inline const char *QueryError_GetError(const QueryError *status) {
+  return status->detail ? status->detail : QueryError_Strerror(status->code);
+}
+
+static inline void QueryError_ClearError(QueryError *err) {
+  if (err->detail) {
+    free(err->detail);
+  }
+  err->code = QUERY_OK;
+}
+
+static inline int QueryError_HasError(const QueryError *status) {
+  return status->code;
+}
+
+static inline void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
+  // Set the code if not previously set. This should be used by code which makes
+  // use of the ::detail field, and is a placeholder for something like:
+  // functionWithCharPtr(&status->detail);
+  // if (status->detail && status->code == QUERY_OK) {
+  //    status->code = MYCODE;
+  // }
+  if (status->detail == NULL) {
+    return;
+  }
+  if (status->code != QUERY_OK) {
+    return;
+  }
+  status->code = code;
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // QUERY_ERROR_H

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -68,9 +68,13 @@ typedef struct {
   int numChildren;
 } QueryTagNode;
 
-typedef struct { struct RSQueryNode *child; } QueryNotNode;
+typedef struct {
+  struct RSQueryNode *child;
+} QueryNotNode;
 
-typedef struct { struct RSQueryNode *child; } QueryOptionalNode;
+typedef struct {
+  struct RSQueryNode *child;
+} QueryOptionalNode;
 
 /* A token node is a terminal, single term/token node. An expansion of synonyms is represented by a
  * Union node with several token nodes. A token can have private metadata written by expanders or
@@ -88,11 +92,17 @@ typedef struct {
 } QueryWildcardNode;
 
 /* A node with a numeric filter */
-typedef struct { struct numericFilter *nf; } QueryNumericNode;
+typedef struct {
+  struct numericFilter *nf;
+} QueryNumericNode;
 
-typedef struct { struct geoFilter *gf; } QueryGeofilterNode;
+typedef struct {
+  struct geoFilter *gf;
+} QueryGeofilterNode;
 
-typedef struct { struct idFilter *f; } QueryIdFilterNode;
+typedef struct {
+  struct idFilter *f;
+} QueryIdFilterNode;
 
 typedef enum {
   QueryNode_Verbatim = 0x01,

--- a/src/query_plan.h
+++ b/src/query_plan.h
@@ -6,6 +6,7 @@
 #include "index_iterator.h"
 #include "result_processor.h"
 #include "query.h"
+#include "query_error.h"
 
 /******************************************************************************************************
  *   Query Plan - the actual binding context of the whole execution plan - from filters to
@@ -64,13 +65,15 @@ typedef struct QueryPlan {
  * it off, resulting in the QueryParseCtx not performing context switches */
 void Query_SetConcurrentMode(QueryPlan *q, int concurrent);
 
-typedef ResultProcessor *(*ProcessorChainBuilder)(QueryPlan *plan, void *privdata, char **err);
+typedef ResultProcessor *(*ProcessorChainBuilder)(QueryPlan *plan, void *privdata,
+                                                  QueryError *status);
 
 /* Build the processor chain of the QueryParseCtx, returning the root processor */
 QueryPlan *Query_BuildPlan(RedisSearchCtx *ctx, QueryParseCtx *parsedQuery, RSSearchOptions *opts,
-                           ProcessorChainBuilder pcb, void *chainBuilderContext, char **err);
+                           ProcessorChainBuilder pcb, void *chainBuilderContext,
+                           QueryError *status);
 
-ResultProcessor *Query_BuildProcessorChain(QueryPlan *q, void *privdata, char **err);
+ResultProcessor *Query_BuildProcessorChain(QueryPlan *q, void *privdata, QueryError *status);
 
 void QueryPlan_SetHook(QueryPlan *plan, QueryPlanHookType ht, QueryHookCallback cb, void *privdata,
                        void (*free)(void *));

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -716,8 +716,7 @@ ResultProcessor *NewLoader(ResultProcessor *upstream, RedisSearchCtx *sctx, Fiel
 /*******************************************************************************************************************
  * Building the processor chaing based on the processors available and the request parameters
  *******************************************************************************************************************/
-ResultProcessor *Query_BuildProcessorChain(QueryPlan *q, void *privdata, char **err) {
-  *err = NULL;
+ResultProcessor *Query_BuildProcessorChain(QueryPlan *q, void *privdata, QueryError *status) {
   RSSearchRequest *req = privdata;
   // The base processor translates index results into search results
   ResultProcessor *next = NewBaseProcessor(q, &q->execCtx);

--- a/src/search_request.h
+++ b/src/search_request.h
@@ -9,6 +9,7 @@
 #include "sortable.h"
 #include "search_options.h"
 #include "query_plan.h"
+#include "query_error.h"
 
 typedef struct {
 
@@ -31,12 +32,13 @@ typedef struct {
 } RSSearchRequest;
 
 RSSearchRequest *ParseRequest(RedisSearchCtx *ctx, RedisModuleString **argv, int argc,
-                              char **errStr);
+                              QueryError *status);
 
 void RSSearchRequest_Free(RSSearchRequest *req);
-QueryParseCtx *SearchRequest_ParseQuery(RedisSearchCtx *sctx, RSSearchRequest *req, char **err);
+QueryParseCtx *SearchRequest_ParseQuery(RedisSearchCtx *sctx, RSSearchRequest *req,
+                                        QueryError *status);
 QueryPlan *SearchRequest_BuildPlan(RedisSearchCtx *sctx, RSSearchRequest *req, QueryParseCtx *q,
-                                   char **err);
+                                   QueryError *error);
 
 // Remove any fields not explicitly requested by `RETURN`, iff any explicit
 // fields actually exist.


### PR DESCRIPTION
This provides us with predefined status codes, alongside a simple
string. This is useful when we need to check the type of failure
*within* the code. In the future we might expose these status codes to
the user, but for the time being it's useful to just be consistent in
our internal error tracking.