### PR TITLE
fixed circle to trigger on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,18 @@ workflows:
 
   default_flow:
     jobs:
-      - ubuntu
-      - centos
+      - ubuntu:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - centos:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - deploy_snapshots:
           requires: *default_jobs
           filters:


### PR DESCRIPTION
According to this https://discuss.circleci.com/t/build-workflow-not-triggered-when-tag-is-pushed/19577/5

We need to add filter to the require jobs also, it looks like it is working.