### PR TITLE
see #529, added support for index expire.

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -49,7 +49,7 @@ void AggregateCommand_ExecAggregateEx(RedisModuleCtx *ctx, RedisModuleString **a
   if (settings->flags & AGGREGATE_REQUEST_SPECLESS) {
     sctx = NewSearchCtxDefault(ctx);
   } else {
-    sctx = NewSearchCtx(ctx, argv[1]);
+    sctx = NewSearchCtx(ctx, argv[1], true);
   }
   if (sctx == NULL) {
     RedisModule_ReplyWithError(ctx, "Unknown Index name");

--- a/src/config.c
+++ b/src/config.c
@@ -73,6 +73,13 @@ CONFIG_SETTER(setSafemode) {
 
 CONFIG_BOOLEAN_GETTER(getSafemode, concurrentMode, 1)
 
+CONFIG_SETTER(setDropAllIndexOnSpecDeletion) {
+  config->dropAllIndexOnSpecDeletion = 1;
+  return REDISMODULE_OK;
+}
+
+CONFIG_BOOLEAN_GETTER(getDropAllIndexOnSpecDeletion, dropAllIndexOnSpecDeletion, 0)
+
 // NOGC
 CONFIG_SETTER(setNoGc) {
   config->enableGC = 0;
@@ -389,6 +396,12 @@ RSConfigOptions RSGlobalConfigOptions = {
          .setValue = setForkGcInterval,
          .getValue = getForkGcInterval,
          .flags = RSCONFIGVAR_F_IMMUTABLE},
+        {
+            .name = "DROP_ALL_INDEX_ON_SPEC_DELETION",
+            .helpText = "should the all index be dropped in case of spec deletion",
+            .setValue = setDropAllIndexOnSpecDeletion,
+            .getValue = getDropAllIndexOnSpecDeletion,
+        },
         {.name = NULL}}};
 
 void RSConfigOptions_AddConfigs(RSConfigOptions *src, RSConfigOptions *dst) {

--- a/src/config.h
+++ b/src/config.h
@@ -14,7 +14,7 @@ typedef enum {
 typedef enum {
   GCPolicy_Default = 0,
   GCPolicy_Fork,
-}GCPolicy;
+} GCPolicy;
 
 const char *TimeoutPolicy_ToString(RSTimeoutPolicy);
 
@@ -76,6 +76,8 @@ typedef struct {
 
   GCPolicy gcPolicy;
   GCPolicy forkGcRunIntervalSec;
+
+  int dropAllIndexOnSpecDeletion;
 
   // Chained configuration data
   void *chainedConfig;
@@ -153,7 +155,8 @@ sds RSConfig_GetInfoString(const RSConfig *config);
     .searchPoolSize = CONCURRENT_SEARCH_POOL_DEFAULT_SIZE,                                      \
     .indexPoolSize = CONCURRENT_INDEX_POOL_DEFAULT_SIZE, .poolSizeNoAuto = 0,                   \
     .gcScanSize = GC_SCANSIZE, .minPhoneticTermLen = DEFAULT_MIN_PHONETIC_TERM_LEN,             \
-    .gcPolicy = GCPolicy_Default, .forkGcRunIntervalSec = DEFAULT_FORK_GC_RUN_INTERVAL          \
+    .gcPolicy = GCPolicy_Default, .forkGcRunIntervalSec = DEFAULT_FORK_GC_RUN_INTERVAL,         \
+    .dropAllIndexOnSpecDeletion = 0                                                             \
   }
 
 #endif

--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -9,25 +9,24 @@
 
 #define DUMP_PHONETIC_HASH "DUMP_PHONETIC_HASH"
 
-#define DEBUG_COMMAND(name) \
-  static int name(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+#define DEBUG_COMMAND(name) static int name(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
-#define GET_SEARCH_CTX(name)\
-  RedisSearchCtx* sctx = NewSearchCtx(ctx, name);\
-  if(!sctx){\
-    RedisModule_ReplyWithError(ctx, "Can not create a search ctx");\
-    return REDISMODULE_OK;\
+#define GET_SEARCH_CTX(name)                                        \
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, name, true);             \
+  if (!sctx) {                                                      \
+    RedisModule_ReplyWithError(ctx, "Can not create a search ctx"); \
+    return REDISMODULE_OK;                                          \
   }
 
-#define REPLY_WITH_LONG_LONG(name, val, len)\
-    RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name));\
-    RedisModule_ReplyWithLongLong(ctx, val);\
-    len += 2;
+#define REPLY_WITH_LONG_LONG(name, val, len)                  \
+  RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name)); \
+  RedisModule_ReplyWithLongLong(ctx, val);                    \
+  len += 2;
 
-#define REPLY_WITH_Str(name, val)\
-    RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name));\
-    RedisModule_ReplyWithStringBuffer(ctx, val, strlen(val));\
-    bulkLen += 2;
+#define REPLY_WITH_Str(name, val)                             \
+  RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name)); \
+  RedisModule_ReplyWithStringBuffer(ctx, val, strlen(val));   \
+  bulkLen += 2;
 
 static void ReplyReaderResults(IndexReader *reader, RedisModuleCtx *ctx) {
   IndexIterator *iter = NewReadIterator(reader);
@@ -51,8 +50,8 @@ static RedisModuleString *getFieldKeyName(IndexSpec *spec, RedisModuleString *fi
   return IndexSpec_GetFormattedKey(spec, fieldSpec);
 }
 
-DEBUG_COMMAND(DumpTerms){
-  if(argc != 1){
+DEBUG_COMMAND(DumpTerms) {
+  if (argc != 1) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -79,8 +78,8 @@ DEBUG_COMMAND(DumpTerms){
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(InvertedIndexSummary){
-  if(argc != 2){
+DEBUG_COMMAND(InvertedIndexSummary) {
+  if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -102,9 +101,9 @@ DEBUG_COMMAND(InvertedIndexSummary){
 
   RedisModule_ReplyWithStringBuffer(ctx, "blocks", strlen("blocks"));
 
-  for(uint32_t i = 0 ; i < invidx->size ; ++i){
+  for (uint32_t i = 0; i < invidx->size; ++i) {
     size_t blockBulkLen = 0;
-    IndexBlock* block = invidx->blocks + i;
+    IndexBlock *block = invidx->blocks + i;
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
     REPLY_WITH_LONG_LONG("firstId", block->firstId, blockBulkLen);
@@ -126,8 +125,8 @@ end:
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(DumpInvertedIndex){
-  if(argc != 2){
+DEBUG_COMMAND(DumpInvertedIndex) {
+  if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -149,8 +148,8 @@ end:
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(NumericIndexSummary){
-  if(argc != 2){
+DEBUG_COMMAND(NumericIndexSummary) {
+  if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -184,8 +183,8 @@ end:
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(DumpNumericIndex){
-  if(argc != 2){
+DEBUG_COMMAND(DumpNumericIndex) {
+  if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -221,8 +220,8 @@ end:
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(DumpTagIndex){
-  if(argc != 2){
+DEBUG_COMMAND(DumpTagIndex) {
+  if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -264,8 +263,8 @@ end:
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(IdToDocId){
-  if(argc != 2){
+DEBUG_COMMAND(IdToDocId) {
+  if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -285,8 +284,8 @@ end:
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(DocIdToId){
-  if(argc != 2){
+DEBUG_COMMAND(DocIdToId) {
+  if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -297,8 +296,8 @@ DEBUG_COMMAND(DocIdToId){
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(DumpPhoneticHash){
-  if(argc != 1){
+DEBUG_COMMAND(DumpPhoneticHash) {
+  if (argc != 1) {
     return RedisModule_WrongArity(ctx);
   }
   size_t len;
@@ -318,34 +317,35 @@ DEBUG_COMMAND(DumpPhoneticHash){
   return REDISMODULE_OK;
 }
 
-static int GCForceInvokeReply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+static int GCForceInvokeReply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 #define REPLY "DONE"
   RedisModule_ReplyWithStringBuffer(ctx, REPLY, strlen(REPLY));
   return REDISMODULE_OK;
 }
 
-static int GCForceInvokeReplyTimeout(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+static int GCForceInvokeReplyTimeout(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 #define ERROR_REPLY "INVOCATION FAILED"
   RedisModule_ReplyWithError(ctx, ERROR_REPLY);
   return REDISMODULE_OK;
 }
 
-DEBUG_COMMAND(GCForceInvoke){
-#define INVOKATION_TIMEOUT 30000 // gc invocation timeout ms
+DEBUG_COMMAND(GCForceInvoke) {
+#define INVOKATION_TIMEOUT 30000  // gc invocation timeout ms
   IndexSpec *sp = IndexSpec_Load(ctx, RedisModule_StringPtrLen(argv[0], NULL), 0);
   if (!sp) {
     RedisModule_ReplyWithError(ctx, "Unknown index name");
     return REDISMODULE_OK;
   }
-  RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, NULL, INVOKATION_TIMEOUT);
+  RedisModuleBlockedClient *bc = RedisModule_BlockClient(
+      ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, NULL, INVOKATION_TIMEOUT);
   GCContext_ForceInvoke(sp->gc, bc);
   return REDISMODULE_OK;
 }
 
-typedef struct DebugCommandType{
-  char* name;
+typedef struct DebugCommandType {
+  char *name;
   int (*callback)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-}DebugCommandType;
+} DebugCommandType;
 
 DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex},
                                {"DUMP_NUMIDX", DumpNumericIndex},
@@ -361,16 +361,16 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex},
 
 int DebugCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
-  if(argc < 2){
+  if (argc < 2) {
     return RedisModule_WrongArity(ctx);
   }
 
-  const char* subCommand = RedisModule_StringPtrLen(argv[1], NULL);
+  const char *subCommand = RedisModule_StringPtrLen(argv[1], NULL);
 
-  if(strcasecmp(subCommand, "help") == 0){
+  if (strcasecmp(subCommand, "help") == 0) {
     size_t len = 0;
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-    for(DebugCommandType* c = &commands[0]; c->name != NULL ; c++){
+    for (DebugCommandType *c = &commands[0]; c->name != NULL; c++) {
       RedisModule_ReplyWithStringBuffer(ctx, c->name, strlen(c->name));
       ++len;
     }
@@ -378,8 +378,8 @@ int DebugCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
   }
 
-  for(DebugCommandType* c = &commands[0]; c->name != NULL ; c++){
-    if(strcasecmp(c->name, subCommand) == 0){
+  for (DebugCommandType *c = &commands[0]; c->name != NULL; c++) {
+    if (strcasecmp(c->name, subCommand) == 0) {
       return c->callback(ctx, argv + 2, argc - 2);
     }
   }

--- a/src/default_gc.c
+++ b/src/default_gc.c
@@ -61,7 +61,8 @@ typedef struct GarbageCollectorCtx {
 } GarbageCollectorCtx;
 
 /* Create a new garbage collector, with a string for the index name, and initial frequency */
-GarbageCollectorCtx* NewGarbageCollector(const RedisModuleString *k, float initialHZ, uint64_t specUniqueId, GCCallbacks* callbacks) {
+GarbageCollectorCtx *NewGarbageCollector(const RedisModuleString *k, float initialHZ,
+                                         uint64_t specUniqueId, GCCallbacks *callbacks) {
   GarbageCollectorCtx *gcCtx = malloc(sizeof(*gcCtx));
 
   *gcCtx = (GarbageCollectorCtx){
@@ -92,7 +93,7 @@ void gc_updateStats(RedisSearchCtx *sctx, GarbageCollectorCtx *gc, size_t record
 
 size_t gc_RandomTerm(RedisModuleCtx *ctx, GarbageCollectorCtx *gc, int *status) {
   RedisModuleKey *idxKey = NULL;
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, (RedisModuleString *)gc->keyName);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, (RedisModuleString *)gc->keyName, false);
   size_t totalRemoved = 0;
   size_t totalCollected = 0;
   if (!sctx || sctx->spec->uniqueId != gc->specUniqueId) {
@@ -216,7 +217,7 @@ size_t gc_TagIndex(RedisModuleCtx *ctx, GarbageCollectorCtx *gc, int *status) {
   size_t totalRemoved = 0;
   char *randomKey = NULL;
   RedisModuleKey *idxKey = NULL;
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, (RedisModuleString *)gc->keyName);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, (RedisModuleString *)gc->keyName, false);
   if (!sctx || sctx->spec->uniqueId != gc->specUniqueId) {
     RedisModule_Log(ctx, "warning", "No index spec for GC %s",
                     RedisModule_StringPtrLen(gc->keyName, NULL));
@@ -295,7 +296,7 @@ size_t gc_NumericIndex(RedisModuleCtx *ctx, GarbageCollectorCtx *gc, int *status
   size_t totalRemoved = 0;
   RedisModuleKey *idxKey = NULL;
   FieldSpec **numericFields = NULL;
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, (RedisModuleString *)gc->keyName);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, (RedisModuleString *)gc->keyName, false);
   if (!sctx || sctx->spec->uniqueId != gc->specUniqueId) {
     RedisModule_Log(ctx, "warning", "No index spec for GC %s",
                     RedisModule_StringPtrLen(gc->keyName, NULL));
@@ -476,4 +477,3 @@ void GC_RenderStats(RedisModuleCtx *ctx, void *gcCtx) {
   }
   RedisModule_ReplySetArrayLength(ctx, n);
 }
-

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -285,7 +285,7 @@ static void ForkGc_CollectGarbageFromTagIdx(ForkGCCtx *gc, RedisSearchCtx *sctx)
 
 static void ForkGc_CollectGarbage(ForkGCCtx *gc) {
   RedisModuleCtx *rctx = RedisModule_GetThreadSafeContext(NULL);
-  RedisSearchCtx *sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName);
+  RedisSearchCtx *sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName, false);
   size_t totalRemoved = 0;
   size_t totalCollected = 0;
   if (!sctx || sctx->spec->uniqueId != gc->specUniqueId) {
@@ -392,7 +392,7 @@ static bool ForkGc_ReadInvertedIndex(ForkGCCtx *gc, int *ret_val, RedisModuleCtx
   RedisModule_ThreadSafeContextLock(rctx);
   RedisModuleKey *idxKey = NULL;
   RedisSearchCtx *sctx = NULL;
-  sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName);
+  sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName, false);
   if (!sctx || sctx->spec->uniqueId != gc->specUniqueId) {
     *ret_val = 0;
     goto cleanup;
@@ -470,7 +470,7 @@ static bool ForkGc_ReadNumericInvertedIndex(ForkGCCtx *gc, int *ret_val, RedisMo
     }
 
     RedisModule_ThreadSafeContextLock(rctx);
-    RedisSearchCtx *sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName);
+    RedisSearchCtx *sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName, false);
     if (!sctx || sctx->spec->uniqueId != gc->specUniqueId) {
       RETURN;
     }
@@ -561,7 +561,7 @@ static bool ForkGc_ReadTagIndex(ForkGCCtx *gc, int *ret_val, RedisModuleCtx *rct
       continue;
     }
 
-    RedisSearchCtx *sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName);
+    RedisSearchCtx *sctx = NewSearchCtx(rctx, (RedisModuleString *)gc->keyName, false);
     if (!sctx || sctx->spec->uniqueId != gc->specUniqueId) {
       RETURN;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -213,7 +213,7 @@ int GetDocumentsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   RedisModule_AutoMemory(ctx);
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1]);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1], true);
   if (sctx == NULL) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
@@ -248,7 +248,7 @@ int GetSingleDocumentCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   }
 
   RedisModule_AutoMemory(ctx);
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1]);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1], true);
   if (sctx == NULL) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
@@ -276,7 +276,7 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
 
   RedisModule_AutoMemory(ctx);
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1]);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1], true);
   if (sctx == NULL) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
@@ -369,7 +369,7 @@ static int queryExplainCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int
   }
 
   RedisModule_AutoMemory(ctx);
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1]);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1], true);
   if (sctx == NULL) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
@@ -602,7 +602,7 @@ void _SearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   // at least one field, and number of field/text args must be even
 
   RedisModule_AutoMemory(ctx);
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1]);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1], true);
   if (sctx == NULL) {
     RedisModule_ReplyWithError(ctx, "Unknown Index name");
     return;
@@ -666,7 +666,7 @@ int TagValsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
 
   RedisModule_AutoMemory(ctx);
-  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1]);
+  RedisSearchCtx *sctx = NewSearchCtx(ctx, argv[1], true);
   if (sctx == NULL) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
@@ -813,7 +813,7 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
-  Redis_DropIndex(&sctx, delDocs);
+  Redis_DropIndex(&sctx, delDocs, true);
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -48,7 +48,7 @@ int Redis_OptimizeScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *
  *  If deleteDocuments is non zero, we will delete the saved documents (if they exist).
  *  Only set this if there are no other indexes in the same redis instance.
  */
-int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments);
+int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments, int deleteSpecKey);
 
 /* Drop all the index's internal keys using this scan handler */
 int Redis_DropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);

--- a/src/search_ctx.h
+++ b/src/search_ctx.h
@@ -23,13 +23,13 @@ typedef struct {
 
 #define SEARCH_CTX_SORTABLES(ctx) ((ctx && ctx->spec) ? ctx->spec->sortables : NULL)
 // Create a string context on the heap
-RedisSearchCtx *NewSearchCtx(RedisModuleCtx *ctx, RedisModuleString *indexName);
+RedisSearchCtx *NewSearchCtx(RedisModuleCtx *ctx, RedisModuleString *indexName, bool resetTTL);
 RedisSearchCtx *NewSearchCtxDefault(RedisModuleCtx *ctx);
 
 RedisSearchCtx *SearchCtx_Refresh(RedisSearchCtx *sctx, RedisModuleString *keyName);
 
 // Same as above, only from c string (null terminated)
-RedisSearchCtx *NewSearchCtxC(RedisModuleCtx *ctx, const char *indexName);
+RedisSearchCtx *NewSearchCtxC(RedisModuleCtx *ctx, const char *indexName, bool resetTTL);
 
 void SearchCtx_Free(RedisSearchCtx *sctx);
 #endif

--- a/src/spec.c
+++ b/src/spec.c
@@ -133,6 +133,9 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   // set the value in redis
   RedisModule_ModuleTypeSetValue(k, IndexSpecType, sp);
+  if (sp->timeout != -1) {
+    RedisModule_SetExpire(k, sp->timeout * 1000);
+  }
 
   if (IndexSpec_OnCreate) {
     IndexSpec_OnCreate(sp);
@@ -439,6 +442,20 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, char *
     spec->flags |= Index_WideSchema;
   }
 
+  int expireOffset = findOffset(SPEC_EXPIRE_STR, argv, argc);
+  if (expireOffset != -1) {
+    if (expireOffset >= argc || expireOffset >= schemaOffset) {
+      SET_ERR(err, "Invalid expire arg");
+      goto failure;
+    }
+    if (sscanf(argv[expireOffset + 1], "%lld", &spec->timeout) != 1) {
+      SET_ERR(err, "Invalid expire arg");
+      goto failure;
+    }
+  } else {
+    spec->timeout = -1;
+  }
+
   int swIndex = findOffset(SPEC_STOPWORDS_STR, argv, argc);
   if (swIndex >= 0 && swIndex + 1 < schemaOffset) {
     int listSize = atoi(argv[swIndex + 1]);
@@ -537,6 +554,13 @@ char *IndexSpec_GetRandomTerm(IndexSpec *sp, size_t sampleSize) {
 void IndexSpec_Free(void *ctx) {
   IndexSpec *spec = ctx;
 
+  if (RSGlobalConfig.dropAllIndexOnSpecDeletion) {
+    RedisModuleCtx *threadCtx = RedisModule_GetThreadSafeContext(NULL);
+    RedisSearchCtx sctx = SEARCH_CTX_STATIC(threadCtx, spec);
+    Redis_DropIndex(&sctx, true, false);
+    RedisModule_FreeThreadSafeContext(threadCtx);
+  }
+
   if (spec->gc) {
     GCContext_Stop(spec->gc);
   }
@@ -597,6 +621,11 @@ IndexSpec *IndexSpec_LoadEx(RedisModuleCtx *ctx, RedisModuleString *formattedKey
   }
 
   IndexSpec *ret = RedisModule_ModuleTypeGetValue(*keyp);
+  if (ret->timeout != -1) {
+    RedisModuleKey *temp = RedisModule_OpenKey(ctx, formattedKey, REDISMODULE_WRITE);
+    RedisModule_SetExpire(temp, ret->timeout * 1000);
+    RedisModule_CloseKey(temp);
+  }
   return ret;
 }
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -23,6 +23,7 @@ typedef enum fieldType { FIELD_FULLTEXT, FIELD_NUMERIC, FIELD_GEO, FIELD_TAG } F
 #define SPEC_NOHL_STR "NOHL"
 #define SPEC_SCHEMA_STR "SCHEMA"
 #define SPEC_SCHEMA_EXPANDABLE_STR "MAXTEXTFIELDS"
+#define SPEC_EXPIRE_STR "EXPIRE"
 #define SPEC_TEXT_STR "TEXT"
 #define SPEC_WEIGHT_STR "WEIGHT"
 #define SPEC_NOSTEM_STR "NOSTEM"
@@ -185,7 +186,7 @@ typedef struct {
 
   StopWordList *stopwords;
 
-  GCContext* gc;
+  GCContext *gc;
 
   SynonymMap *smap;
 
@@ -193,6 +194,7 @@ typedef struct {
 
   RedisModuleCtx *strCtx;
   RedisModuleString **indexStrs;
+  long long timeout;
 } IndexSpec;
 
 extern RedisModuleType *IndexSpecType;


### PR DESCRIPTION
When creating an index it is now possible to specify EXPIRE <ttl in seconds>
In addition it is possible to upload the module with DROP_ALL_INDEX_ON_SPEC_DELETION option so
when the index will expire all the index document will be dropped.