### PR TITLE
fix doc relative url.

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -1,6 +1,6 @@
 # Run-time configuration
 
-RediSearch supports a few run-time configuration options that should be determined when loading the module. In time more options will be added. 
+RediSearch supports a few run-time configuration options that should be determined when loading the module. In time more options will be added.
 
 ## Passing Configuration Options During Loading
 
@@ -26,7 +26,7 @@ $ redis-server --loadmodule ./redisearch.so OPT1 OPT2
 
 ## Setting Configuration Options In Run-Time
 
-As of v1.4.1, the [`FT.CONFIG`](/Commands/#ftconfig) allows setting some options during runtime. In addition, the command can be used to view the current run-time configuration options.
+As of v1.4.1, the [`FT.CONFIG`](/redisearch/Commands/#ftconfig) allows setting some options during runtime. In addition, the command can be used to view the current run-time configuration options.
 
 # RediSearch configuration options
 
@@ -89,7 +89,7 @@ $ redis-server --loadmodule ./redisearch.so SAFEMODE
 
 ## EXTLOAD {file_name}
 
-If present, we try to load a RediSearch extension dynamic library from the specified file path. See [Extensions](/Extensions) for details.
+If present, we try to load a RediSearch extension dynamic library from the specified file path. See [Extensions](/redisearch/Extensions) for details.
 
 ### Default
 
@@ -169,7 +169,7 @@ $ redis-server --loadmodule ./redisearch.so MAXDOCTABLESIZE 3000000
 
 ## FRISOINI {file_name}
 
-If present, we load the custom Chinese dictionary from the specified path. See [Using custom dictionaries](/Chinese#using_custom_dictionaries) for more details.
+If present, we load the custom Chinese dictionary from the specified path. See [Using custom dictionaries](/redisearch/Chinese#using_custom_dictionaries) for more details.
 
 ### Default
 
@@ -183,7 +183,7 @@ $ redis-server --loadmodule ./redisearch.so FRISOINI /opt/dict/friso.ini
 
 ---
 
-## GC_SCANSIZE 
+## GC_SCANSIZE
 
 The garbage collection bulk size of the internal gc used for cleaning up the indexes.
 

--- a/docs/Escaping.md
+++ b/docs/Escaping.md
@@ -1,17 +1,17 @@
 # Controlling Text Tokenization and Escaping
 
-At the moment, RediSearch uses a very simple tokenizer for documents and a slightly more sophisticated tokenizer for queries. Both allow a degree of control over string escaping and tokenization. 
+At the moment, RediSearch uses a very simple tokenizer for documents and a slightly more sophisticated tokenizer for queries. Both allow a degree of control over string escaping and tokenization.
 
-Note: There is a different mechanism for tokenizing text and tag fields, this document refers only to text fields. For tag fields please refer to the [Tag Fields](/Tags) documentation. 
+Note: There is a different mechanism for tokenizing text and tag fields, this document refers only to text fields. For tag fields please refer to the [Tag Fields](/redisearch/Tags) documentation. 
 
 ## The rules of text field tokenization
 
 1. All punctuation marks and whitespaces (besides underscores) separate the document and queries into tokens. e.g. any character of `,.<>{}[]"':;!@#$%^&*()-+=~` will break the text into terms.  So the text `foo-bar.baz...bag` will be tokenized into `[foo, bar, baz, bag]`
 
-2. Escaping separators in both queries and documents is done by prepending a backslash to any separator. e.g. the text `hello\-world hello-world` will be tokenized as `[hello-world, hello, world]`. **NOTE** that in most languages you will need an extra backslash when formatting the document or query, to signify an actual backslash, so the actual text in redis-cli for example, will be entered as `hello\\-world`. 
+2. Escaping separators in both queries and documents is done by prepending a backslash to any separator. e.g. the text `hello\-world hello-world` will be tokenized as `[hello-world, hello, world]`. **NOTE** that in most languages you will need an extra backslash when formatting the document or query, to signify an actual backslash, so the actual text in redis-cli for example, will be entered as `hello\\-world`.
 
-2. Underscores (`_`) are not used as separators in either document or query. So the text `hello_world` will remain as is after tokenization. 
+2. Underscores (`_`) are not used as separators in either document or query. So the text `hello_world` will remain as is after tokenization.
 
-3. Repeating spaces or punctuation marks are stripped. 
+3. Repeating spaces or punctuation marks are stripped.
 
-4. In Latin characters, everything gets converted to lowercase. 
+4. In Latin characters, everything gets converted to lowercase.

--- a/docs/Phonetic_Matching.md
+++ b/docs/Phonetic_Matching.md
@@ -6,7 +6,7 @@ Phonetic matching is based on the use of a phonetic algorithm. A phonetic algori
 
 As of v1.4 RediSearch provides phonetic matching via the definition of text fields with the `PHONETIC` attribute. This causes the terms in such fields to be indexed both by their textual value as well as their phonetic approximation.
 
-Performing a search on `PHONETIC` fields will, by default, also return results for phonetically similar terms. This behavior can be controlled with the [`$phonetic` query attribute](/Query_Syntax/#query_attributes).
+Performing a search on `PHONETIC` fields will, by default, also return results for phonetically similar terms. This behavior can be controlled with the [`$phonetic` query attribute](/redisearch/Query_Syntax/#query_attributes).
 
 ## Phonetic algorithms support
 

--- a/docs/Scoring.md
+++ b/docs/Scoring.md
@@ -1,8 +1,8 @@
 # Scoring in RediSearch
 
-RediSearch comes with a few very basic scoring functions to evaluate document relevance. They are all based on document scores and term frequency. This is regardless of the ability to use [sortable fields](/Sorting/). Scoring functions are specified by adding the `SCORER {scorer_name}` argument to a search query.
+RediSearch comes with a few very basic scoring functions to evaluate document relevance. They are all based on document scores and term frequency. This is regardless of the ability to use [sortable fields](/redisearch/Sorting/). Scoring functions are specified by adding the `SCORER {scorer_name}` argument to a search query.
 
-If you prefer a custom scoring function, it is possible to add more functions using the [Extension API](/Extensions).
+If you prefer a custom scoring function, it is possible to add more functions using the [Extension API](/redisearch/Extensions).
 
 These are the pre-bundled scoring functions available in RediSearch and how they work. Each function is mentioned by registered name, that can be passed as a `SCORER` argument in `FT.SEARCH`.
 

--- a/docs/Spellcheck.md
+++ b/docs/Spellcheck.md
@@ -10,14 +10,14 @@ In such cases and as of v1.4 RediSearch can be used for generating alternatives 
 
 The alternatives for a misspelled term are generated from the corpus of already-indexed terms and, optionally, one or more custom dictionaries. Alternatives become spelling suggestions based on their respective Levenshtein distances (LD) from the misspelled term. Each spelling suggestion is given a normalized score based on its occurances in the index.
 
-To obtain the spelling corrections for a query, refer to the documentation of the [`FT.SPELLCHECK`](/Commands/#ftspellcheck) command.
+To obtain the spelling corrections for a query, refer to the documentation of the [`FT.SPELLCHECK`](/redisearch/Commands/#ftspellcheck) command.
 
 ## Custom dictionaries
 
-A dictionary is a set of terms. Dictionaries can be added with terms, have terms deleted from them and have their entire contents dumped using the [`FT.DICTADD`](Commands/#ftdictadd), [`FT.DICTDEL`](/Commands/#ftdictdel) and [`FT.DICTDUMP`](/Commands/#ftdictdump) commands, respectively.
+A dictionary is a set of terms. Dictionaries can be added with terms, have terms deleted from them and have their entire contents dumped using the [`FT.DICTADD`](/redisearch/Commands/#ftdictadd), [`FT.DICTDEL`](/redisearch/Commands/#ftdictdel) and [`FT.DICTDUMP`](/redisearch/Commands/#ftdictdump) commands, respectively.
 
 Dictionaries can be used to modify the behavior of RediSearch's query spelling correction, by including or excluding their contents from potential spelling correction suggestions.
 
-When used for term inclusion, the terms in a dictionary can be provided as spelling suggestions regardless their occurances (or lack of) in the index. Scores of suggestions from inclusion dictionaries are always 0. 
+When used for term inclusion, the terms in a dictionary can be provided as spelling suggestions regardless their occurances (or lack of) in the index. Scores of suggestions from inclusion dictionaries are always 0.
 
 Conversely, terms in an exlusion dictionary will never be returned as spelling alternatives.

--- a/docs/Stopwords.md
+++ b/docs/Stopwords.md
@@ -1,14 +1,14 @@
 # Stop-Words
 
-RediSearch has a pre-defined default list of [stop-words](https://en.wikipedia.org/wiki/Stop_words). These are words that are usually so common that they do not add much information to search, but take up a lot of space and CPU time in the index. 
+RediSearch has a pre-defined default list of [stop-words](https://en.wikipedia.org/wiki/Stop_words). These are words that are usually so common that they do not add much information to search, but take up a lot of space and CPU time in the index.
 
-When indexing, stop-words are discarded and not indexed. When searching, they are also ignored and treated as if they were not sent to the query processor. This is done when parsing the query. 
+When indexing, stop-words are discarded and not indexed. When searching, they are also ignored and treated as if they were not sent to the query processor. This is done when parsing the query.
 
-At the moment, the default stop-word list applies to all full-text indexes in all languages and can be overridden manually at index creation time. 
+At the moment, the default stop-word list applies to all full-text indexes in all languages and can be overridden manually at index creation time.
 
 ## Default stop-word list
 
-The following words are treated as stop-words by default: 
+The following words are treated as stop-words by default:
 
 ```
  a,    is,    the,   an,   and,  are, as,  at,   be,   but,  by,   for,
@@ -18,12 +18,12 @@ The following words are treated as stop-words by default:
 
 ## Overriding the default stop-words
 
-Stop-words for an index can be defined (or disabled completely) on index creation using the `STOPWORDS` argument in the [FT.CREATE](/Commands/#ftcreate) command.
+Stop-words for an index can be defined (or disabled completely) on index creation using the `STOPWORDS` argument in the [FT.CREATE](/redisearch/Commands/#ftcreate) command.
 
 The format is `STOPWORDS {number} {stopword} ...` where number is the number of stopwords given. The `STOPWORDS` argument must come before the `SCHEMA` argument. For example:
 
 ```
-FT.CREATE myIndex STOPWORDS 3 foo bar baz SCHEMA title TEXT body TEXT 
+FT.CREATE myIndex STOPWORDS 3 foo bar baz SCHEMA title TEXT body TEXT
 ```
 
 ## Disabling stop-words completely
@@ -33,4 +33,4 @@ Disabling stopwords completely can be done by passing `STOPWORDS 0` on `FT.CREAT
 
 ## Avoiding stop-word detection in search queries
 
-In rare use cases, where queries are very long and are guaranteed by the client application to not contain stopwords, it is possible to avoid checking for them when parsing the query. This saves some CPU time and is only worth it if the query has dozens or more terms in it. Using this without verifying that the query doesn't contain stop-words might result in empty queries. 
+In rare use cases, where queries are very long and are guaranteed by the client application to not contain stopwords, it is possible to avoid checking for them when parsing the query. This saves some CPU time and is only worth it if the query has dozens or more terms in it. Using this without verifying that the query doesn't contain stop-words might result in empty queries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,36 +2,36 @@
 
 # RediSearch - Redis Powered Search Engine
 
-RediSearch is a an open-source Full-Text and Secondary Index engine over Redis, developed by [Redis Labs](http://redislabs.com). 
+RediSearch is a an open-source Full-Text and Secondary Index engine over Redis, developed by [Redis Labs](http://redislabs.com).
 
 !!! note "Quick Links:"
     * [Source Code at GitHub](https://github.com/RedisLabsModules/RediSearch).
     * [Latest Release: 1.4.2](https://github.com/RedisLabsModules/RediSearch/releases)
     * [Docker Image: redislabs/redisearch](https://hub.docker.com/r/redislabs/redisearch/)
-    * [Quick Start Guide](/Quick_Start)
+    * [Quick Start Guide](/redisearch/Quick_Start)
     * [Mailing list / Forum](https://groups.google.com/forum/#!forum/redisearch)
 
 !!! tip "Supported Platforms"
     RediSearch is developed and tested on Linux and Mac OS, on x86_64 CPUs.
 
-    i386 CPUs should work fine for small data-sets, but are not tested and not recommended. Atom CPUs are not supported currently. 
+    i386 CPUs should work fine for small data-sets, but are not tested and not recommended. Atom CPUs are not supported currently.
 
 ## Overview
 
-Redisearch implements a search engine on top of Redis, but unlike other Redis 
+Redisearch implements a search engine on top of Redis, but unlike other Redis
 search libraries, it does not use internal data structures like sorted sets.
 
-This also enables more advanced features, like exact phrase matching and numeric filtering for text queries, 
+This also enables more advanced features, like exact phrase matching and numeric filtering for text queries,
 that are not possible or efficient with traditional Redis search approaches.
 
 ## Client Libraries
 
-Official and community client libraries in Python, Java, JavaScript, Ruby, Go, C#, and PHP. 
-See [Clients Page](/Clients)
+Official and community client libraries in Python, Java, JavaScript, Ruby, Go, C#, and PHP.
+See [Clients Page](/redisearch/Clients)
 
 ## Cluster Support and Commercial Version
 
-RediSearch has a distributed cluster version that can scale to billions of documents and hundreds of servers. However, it is only available as part of Redis Labs Enterprise. We also offer official commercial support for RediSearch. See the [Redis Labs Website](https://redislabs.com/redis-enterprise/technology/redis-search/#sds) for more info and contact information. 
+RediSearch has a distributed cluster version that can scale to billions of documents and hundreds of servers. However, it is only available as part of Redis Labs Enterprise. We also offer official commercial support for RediSearch. See the [Redis Labs Website](https://redislabs.com/redis-enterprise/technology/redis-search/#sds) for more info and contact information.
 
 ## Primary Features
 
@@ -44,14 +44,12 @@ RediSearch has a distributed cluster version that can scale to billions of docum
 * Field weights.
 * Auto-complete suggestions (with fuzzy prefix suggestions).
 * Exact Phrase Search, Slop based search.
-* Stemming based query expansion in [many languages](/Stemming/) (using [Snowball](http://snowballstem.org/)).
-* Support for custom functions for query expansion and scoring (see [Extensions](/Extensions)).
+* Stemming based query expansion in [many languages](/redisearch/Stemming/) (using [Snowball](http://snowballstem.org/)).
+* Support for custom functions for query expansion and scoring (see [Extensions](/redisearch/Extensions)).
 * Limiting searches to specific document fields.
 * Numeric filters and ranges.
-* Geo filtering using Redis' own Geo-commands. 
+* Geo filtering using Redis' own Geo-commands.
 * Unicode support (UTF-8 input required).
 * Retrieve full document content or just ids
 * Document deletion and updating with index garbage collection.
 * Partial and conditional document updates.
-
-

--- a/docs/python_client.md
+++ b/docs/python_client.md
@@ -60,7 +60,7 @@ suggs = ac.get_suggestions('goo', fuzzy = True) # returns ['foo']
 
 1. Install Redis 4.0 or above
 
-2. [Install RediSearch](https://oss.redislabs.com/redisearch/Quick_Start/#building-and-running)
+2. [Install RediSearch](/redisearch/Quick_Start/#building-and-running)
 
 3. Install the python client
 


### PR DESCRIPTION
some inside link cannot open since the doc web migrate from `https://redisearch.io` to `https://oss.redislabs.com/redisearch/`.

Also, the #555 did the same work.
