### PR TITLE
Fix broken doc links - use absolute .md links

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -62,7 +62,7 @@ Creates an index with the given spec. The index name will be used in all the key
 
     * **SORTABLE**
     
-        Numeric, tag or text field can have the optional SORTABLE argument that allows the user to later [sort the results by the value of this field](Sorting) (this adds memory overhead so do not declare it on large text fields).
+        Numeric, tag or text field can have the optional SORTABLE argument that allows the user to later [sort the results by the value of this field](Sorting.md) (this adds memory overhead so do not declare it on large text fields).
       
     * **NOSTEM**
     
@@ -83,7 +83,7 @@ Creates an index with the given spec. The index name will be used in all the key
         * `dm:pt` - Double Metaphone for Portuguese
         * `dm:es` - Double Metaphone for Spanish
     
-        For more details see [Phonetic Matching](Phonetic_Matching).
+        For more details see [Phonetic Matching](Phonetic_Matching.md).
 
 ### Complexity
 O(1)
@@ -150,7 +150,7 @@ Adds a document to the index.
 
   The expression is evaluated atomically before the update, ensuring that the update will happen only if it is true.
 
-  See [Aggregations](Aggregations) for more details on the expression language. 
+  See [Aggregations](Aggregations.md) for more details on the expression language. 
 
 - **LANGUAGE language**: If set, we use a stemmer for the supplied language during indexing. Default
   to English. 
@@ -172,7 +172,7 @@ order for the indexer to properly tokenize the terms. If the default language
 is used then search terms will be extracted based on punctuation characters and
 whitespace. The Chinese language tokenizer makes use of a segmentation algorithm
 (via [Friso](https://github.com/lionsoul2014/friso)) which segments texts and
-checks it against a predefined dictionary. See [Stemming](Stemming) for more
+checks it against a predefined dictionary. See [Stemming](Stemming.md) for more
 information.
 
 ### Complexity
@@ -385,7 +385,7 @@ Searches the index with a textual query, returning either documents or just ids.
 
 - **index**: The index name. The index must be first created with `FT.CREATE`.
 - **query**: the text query to search. If it's more than a single word, put it in quotes.
-  Refer to [query syntax](Query_Syntax) for more details. 
+  Refer to [query syntax](Query_Syntax.md) for more details. 
   
 - **NOCONTENT**: If it appears after the query, we only return the document ids and not 
   the content. This is useful if RediSearch is only an index on an external document collection
@@ -418,8 +418,8 @@ Searches the index with a textual query, returning either documents or just ids.
   `num` is the number of fields following the keyword. If `num` is 0, it acts like `NOCONTENT`.  
 - **SUMMARIZE ...**: Use this option to return only the sections of the field which contain the 
   matched text.
-  See [Highlighting](Highlight) for more details
-- **HIGHLIGHT ...**: Use this option to format occurrences of matched text. See [Highligting](Highlight) for more
+  See [Highlighting](Highlight.md) for more details
+- **HIGHLIGHT ...**: Use this option to format occurrences of matched text. See [Highligting](Highlight.md) for more
   details
 - **SLOP {slop}**: If set, we allow a maximum of N intervening number of unmatched offsets between 
   phrase terms. (i.e the slop for exact phrases is 0)
@@ -432,12 +432,12 @@ Searches the index with a textual query, returning either documents or just ids.
   Defaults to English. If an unsupported language is sent, the command returns an error.
   See FT.ADD for the list of languages.
 
-- **EXPANDER {expander}**: If set, we will use a custom query expander instead of the stemmer. [See Extensions](Extensions).
-- **SCORER {scorer}**: If set, we will use a custom scoring function defined by the user. [See Extensions](Extensions).
+- **EXPANDER {expander}**: If set, we will use a custom query expander instead of the stemmer. [See Extensions](Extensions.md).
+- **SCORER {scorer}**: If set, we will use a custom scoring function defined by the user. [See Extensions](Extensions.md).
 - **PAYLOAD {payload}**: Add an arbitrary, binary safe payload that will be exposed to custom scoring 
-  functions. [See Extensions](Extensions).
+  functions. [See Extensions](Extensions.md).
   
-- **SORTBY {field} [ASC|DESC]**: If specified, and field is a [sortable field](Sorting), the results 
+- **SORTBY {field} [ASC|DESC]**: If specified, and field is a [sortable field](Sorting.md), the results 
   are ordered by the value of this field. This applies to both text and numeric fields.
 - **LIMIT first num**: If the parameters appear after the query, we limit the results to 
   the offset and number of results given. The default is 0 10
@@ -477,7 +477,7 @@ FT.AGGREGATE  {index_name}
 
 ### Description
 
-Runs a search query on an index, and performs aggregate transformations on the results, extracting statistics etc from them. See [the full documentation on aggregations](Aggregations) for further details.
+Runs a search query on an index, and performs aggregate transformations on the results, extracting statistics etc from them. See [the full documentation on aggregations](Aggregations.md) for further details.
 
 ### Parameters
 
@@ -776,7 +776,7 @@ FT.TAGVALS {index} {field_name}
 
 ### Description
 
-Returns the distinct tags indexed in a [Tag field](Tags). 
+Returns the distinct tags indexed in a [Tag field](Tags.md). 
 
 This is useful if your tag field indexes things like cities, categories, etc.
 
@@ -784,7 +784,7 @@ This is useful if your tag field indexes things like cities, categories, etc.
 
       There is no paging or sorting, the tags are not alphabetically sorted. 
     
-      This command only operates on [Tag fields](Tags).  
+      This command only operates on [Tag fields](Tags.md).  
     
       The strings return lower-cased and stripped of whitespaces, but otherwise unchanged.
 
@@ -985,7 +985,7 @@ The command is used to dump the synonyms data structure. Returns a list of synon
 
 Performs spelling correction on a query, returning suggestions for misspelled terms.
 
-See [Query Spelling Correction](Spellcheck) for more details.
+See [Query Spelling Correction](Spellcheck.md) for more details.
 
 ### Parameters
 
@@ -993,7 +993,7 @@ See [Query Spelling Correction](Spellcheck) for more details.
 
 * **query**: the search query.
 
-* **TERMS**: specifies an inclusion (`INCLUDE`) or exclusion (`EXCLUDE`) custom dictionary named `{dict}`. Refer to [`FT.DICTADD`](Commands/#ftdictadd), [`FT.DICTDEL`](Commands/#ftdictdel) and [`FT.DICTDUMP`](Commands/#ftdictdump) for managing custom dictionaries.
+* **TERMS**: specifies an inclusion (`INCLUDE`) or exclusion (`EXCLUDE`) custom dictionary named `{dict}`. Refer to [`FT.DICTADD`](Commands.md#ftdictadd), [`FT.DICTDEL`](Commands.md#ftdictdel) and [`FT.DICTDUMP`](Commands.md#ftdictdump) for managing custom dictionaries.
 
 * **DISTANCE**: the maximal Levenshtein distance for spelling suggestions (default: 1, max: 4).
 
@@ -1119,7 +1119,7 @@ Retrieves, describes and sets runtime configuration options.
 * **option**: the name of the configuration option, or '*' for all.
 * **value**: a value for the configuration option.
 
-For details about the configuration options refer to [Configuring](Configuring).
+For details about the configuration options refer to [Configuring](Configuring.md).
 
 Setting values in runtime is supported for these configuration options:
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -26,7 +26,7 @@ $ redis-server --loadmodule ./redisearch.so OPT1 OPT2
 
 ## Setting Configuration Options In Run-Time
 
-As of v1.4.1, the [`FT.CONFIG`](Commands/#ftconfig) allows setting some options during runtime. In addition, the command can be used to view the current run-time configuration options.
+As of v1.4.1, the [`FT.CONFIG`](Commands.md#ftconfig) allows setting some options during runtime. In addition, the command can be used to view the current run-time configuration options.
 
 # RediSearch configuration options
 
@@ -89,7 +89,7 @@ $ redis-server --loadmodule ./redisearch.so SAFEMODE
 
 ## EXTLOAD {file_name}
 
-If present, we try to load a RediSearch extension dynamic library from the specified file path. See [Extensions](Extensions) for details.
+If present, we try to load a RediSearch extension dynamic library from the specified file path. See [Extensions](Extensions.md) for details.
 
 ### Default
 
@@ -169,7 +169,7 @@ $ redis-server --loadmodule ./redisearch.so MAXDOCTABLESIZE 3000000
 
 ## FRISOINI {file_name}
 
-If present, we load the custom Chinese dictionary from the specified path. See [Using custom dictionaries](Chinese/#using_custom_dictionaries) for more details.
+If present, we load the custom Chinese dictionary from the specified path. See [Using custom dictionaries](Chinese.md#using_custom_dictionaries) for more details.
 
 ### Default
 

--- a/docs/Escaping.md
+++ b/docs/Escaping.md
@@ -2,7 +2,7 @@
 
 At the moment, RediSearch uses a very simple tokenizer for documents and a slightly more sophisticated tokenizer for queries. Both allow a degree of control over string escaping and tokenization. 
 
-Note: There is a different mechanism for tokenizing text and tag fields, this document refers only to text fields. For tag fields please refer to the [Tag Fields](Tags) documentation. 
+Note: There is a different mechanism for tokenizing text and tag fields, this document refers only to text fields. For tag fields please refer to the [Tag Fields](Tags.md) documentation. 
 
 ## The rules of text field tokenization
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -212,7 +212,7 @@ And negative clauses can also be added, in this example to filter out plasma and
 
 RediSearch comes with a few very basic scoring functions to evaluate document relevance. They are all based on document scores and term frequency. This is regardless of the ability to use sortable fields (see below). Scoring functions are specified by adding the `SCORER {scorer_name}` argument to a search request.
 
-If you prefer a custom scoring function, it is possible to add more functions using the [Extension API](Extensions).
+If you prefer a custom scoring function, it is possible to add more functions using the [Extension API](Extensions.md).
 
 These are the pre-bundled scoring functions available in RediSearch:
 

--- a/docs/Phonetic_Matching.md
+++ b/docs/Phonetic_Matching.md
@@ -6,7 +6,7 @@ Phonetic matching is based on the use of a phonetic algorithm. A phonetic algori
 
 As of v1.4 RediSearch provides phonetic matching via the definition of text fields with the `PHONETIC` attribute. This causes the terms in such fields to be indexed both by their textual value as well as their phonetic approximation.
 
-Performing a search on `PHONETIC` fields will, by default, also return results for phonetically similar terms. This behavior can be controlled with the [`$phonetic` query attribute](Query_Syntax/#query_attributes).
+Performing a search on `PHONETIC` fields will, by default, also return results for phonetically similar terms. This behavior can be controlled with the [`$phonetic` query attribute](Query_Syntax.md#query_attributes).
 
 ## Phonetic algorithms support
 

--- a/docs/Scoring.md
+++ b/docs/Scoring.md
@@ -1,8 +1,8 @@
 # Scoring in RediSearch
 
-RediSearch comes with a few very basic scoring functions to evaluate document relevance. They are all based on document scores and term frequency. This is regardless of the ability to use [sortable fields](Sorting). Scoring functions are specified by adding the `SCORER {scorer_name}` argument to a search query.
+RediSearch comes with a few very basic scoring functions to evaluate document relevance. They are all based on document scores and term frequency. This is regardless of the ability to use [sortable fields](Sorting.md). Scoring functions are specified by adding the `SCORER {scorer_name}` argument to a search query.
 
-If you prefer a custom scoring function, it is possible to add more functions using the [Extension API](Extensions).
+If you prefer a custom scoring function, it is possible to add more functions using the [Extension API](Extensions.md).
 
 These are the pre-bundled scoring functions available in RediSearch and how they work. Each function is mentioned by registered name, that can be passed as a `SCORER` argument in `FT.SEARCH`.
 

--- a/docs/Spellcheck.md
+++ b/docs/Spellcheck.md
@@ -10,11 +10,11 @@ In such cases and as of v1.4 RediSearch can be used for generating alternatives 
 
 The alternatives for a misspelled term are generated from the corpus of already-indexed terms and, optionally, one or more custom dictionaries. Alternatives become spelling suggestions based on their respective Levenshtein distances (LD) from the misspelled term. Each spelling suggestion is given a normalized score based on its occurances in the index.
 
-To obtain the spelling corrections for a query, refer to the documentation of the [`FT.SPELLCHECK`](Commands/#ftspellcheck) command.
+To obtain the spelling corrections for a query, refer to the documentation of the [`FT.SPELLCHECK`](Commands.md#ftspellcheck) command.
 
 ## Custom dictionaries
 
-A dictionary is a set of terms. Dictionaries can be added with terms, have terms deleted from them and have their entire contents dumped using the [`FT.DICTADD`](Commands/#ftdictadd), [`FT.DICTDEL`](Commands/#ftdictdel) and [`FT.DICTDUMP`](Commands/#ftdictdump) commands, respectively.
+A dictionary is a set of terms. Dictionaries can be added with terms, have terms deleted from them and have their entire contents dumped using the [`FT.DICTADD`](Commands.md#ftdictadd), [`FT.DICTDEL`](Commands.md#ftdictdel) and [`FT.DICTDUMP`](Commands.md#ftdictdump) commands, respectively.
 
 Dictionaries can be used to modify the behavior of RediSearch's query spelling correction, by including or excluding their contents from potential spelling correction suggestions.
 

--- a/docs/Stopwords.md
+++ b/docs/Stopwords.md
@@ -18,7 +18,7 @@ The following words are treated as stop-words by default:
 
 ## Overriding the default stop-words
 
-Stop-words for an index can be defined (or disabled completely) on index creation using the `STOPWORDS` argument in the [FT.CREATE](Commands/#ftcreate) command.
+Stop-words for an index can be defined (or disabled completely) on index creation using the `STOPWORDS` argument in the [FT.CREATE](Commands.md#ftcreate) command.
 
 The format is `STOPWORDS {number} {stopword} ...` where number is the number of stopwords given. The `STOPWORDS` argument must come before the `SCHEMA` argument. For example:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ RediSearch is a an open-source Full-Text and Secondary Index engine over Redis, 
     * [Source Code at GitHub](https://github.com/RedisLabsModules/RediSearch).
     * [Latest Release: 1.4.2](https://github.com/RedisLabsModules/RediSearch/releases)
     * [Docker Image: redislabs/redisearch](https://hub.docker.com/r/redislabs/redisearch/)
-    * [Quick Start Guide](Quick_Start)
+    * [Quick Start Guide](Quick_Start.md)
     * [Mailing list / Forum](https://groups.google.com/forum/#!forum/redisearch)
 
 !!! tip "Supported Platforms"
@@ -28,7 +28,7 @@ that are not possible or efficient with traditional Redis search approaches.
 
 Official and community client libraries in Python, Java, JavaScript, Ruby, Go, C#, and PHP. 
 
-See the [Clients page](Clients) for the full list.
+See the [Clients page](Clients.md) for the full list.
 
 ## Cluster Support and Commercial Version
 
@@ -45,8 +45,8 @@ RediSearch has a distributed cluster version that can scale to billions of docum
 * Field weights.
 * Auto-complete suggestions (with fuzzy prefix suggestions).
 * Exact Phrase Search, Slop based search.
-* Stemming based query expansion in [many languages](Stemming) (using [Snowball](http://snowballstem.org/)).
-* Support for custom functions for query expansion and scoring (see [Extensions](Extensions)).
+* Stemming based query expansion in [many languages](Stemming.md) (using [Snowball](http://snowballstem.org/)).
+* Support for custom functions for query expansion and scoring (see [Extensions](Extensions.md)).
 * Limiting searches to specific document fields.
 * Numeric filters and ranges.
 * Geo filtering using Redis' own Geo-commands. 

--- a/docs/python_client.md
+++ b/docs/python_client.md
@@ -60,7 +60,7 @@ suggs = ac.get_suggestions('goo', fuzzy = True) # returns ['foo']
 
 1. Install Redis 4.0 or above
 
-2. [Install RediSearch](https://oss.redislabs.com/redisearch/Quick_Start/#building-and-running)
+2. [Install RediSearch](https://oss.redislabs.com/redisearch/Quick_Start.md#building-and-running)
 
 3. Install the python client
 

--- a/docs/python_client.md
+++ b/docs/python_client.md
@@ -60,7 +60,7 @@ suggs = ac.get_suggestions('goo', fuzzy = True) # returns ['foo']
 
 1. Install Redis 4.0 or above
 
-2. [Install RediSearch](https://oss.redislabs.com/redisearch/Quick_Start.md#building-and-running)
+2. [Install RediSearch](https://oss.redislabs.com/redisearch/Quick_Start/#building-and-running)
 
 3. Install the python client
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ markdown_extensions:
       separator: "_"
   - admonition
   
-use_directory_urls: true
+use_directory_urls: false
 theme:
   name: 'material'
   language: 'en'


### PR DESCRIPTION
These absolute links (as is normal in Markdown) get translated to their
proper equivalents with mkdoc. Without markdown links, mkdocs just
passes these links through verbatim.