### PR TITLE
fix(spellcheck): Free only if include, exclude dicts are allocated

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -344,8 +344,12 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   SpellCheck_Reply(&scCtx, &qast);
 
 end:
-  array_free(includeDict);
-  array_free(excludeDict);
+  if (includeDict != NULL) {
+    array_free(includeDict);
+  }
+  if (excludeDict != NULL) {
+    array_free(excludeDict);
+  }
   QAST_Destroy(&qast);
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -1949,6 +1949,11 @@ def testIssue501(env):
     env.assertEqual("qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq", rv[0][1])
     env.assertEqual([], rv[0][2])
 
+def testIssue589(env):
+    env.cmd('FT.CREATE', 'incidents', 'SCHEMA', 'report', 'TEXT')
+    env.cmd('FT.ADD', 'incidents', 'doc1', 1.0, 'FIELDS', 'report', 'report content')
+    env.expect('FT.SPELLCHECK', 'incidents', 'report :').error().contains("Syntax error at offset")
+
 def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
     from itertools import izip_longest


### PR DESCRIPTION
Fixes #589 