### PR TITLE
preallocate entire doctable if maxid is bigger than cap (#595)

### DIFF
--- a/.circleci/ci_test.sh
+++ b/.circleci/ci_test.sh
@@ -4,7 +4,8 @@ set -x
 
 pip install wheel
 pip install setuptools --upgrade
-pip install git+https://github.com/RedisLabsModules/RLTest.git@master
+pip install git+https://github.com/RedisLabsModules/RLTest.git
+pip install redis-py-cluster
 
 PROJECT_DIR=$PWD
 cd $PROJECT_DIR/$BUILD_DIR


### PR DESCRIPTION
This ensures every single index in the doctable is valid even if there
isn't a valid ID mapping to a valid bucket on load-time