### PR TITLE
Clean up geo fields on REPLACE (#588)

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -82,6 +82,9 @@ static int AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp, Doc
           hasTextFields = 1;
         } else {
           hasOtherFields = 1;
+          if (fs->type == FIELD_GEO) {
+            aCtx->docFlags = Document_HasOnDemandDeletable;
+          }
         }
       }
     } else {
@@ -126,6 +129,7 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *b, QueryError *stat
   aCtx->stateFlags = 0;
   QueryError_ClearError(&aCtx->status);
   aCtx->totalTokens = 0;
+  aCtx->docFlags = 0;
   aCtx->client.bc = NULL;
   aCtx->next = NULL;
   aCtx->specFlags = sp->flags;

--- a/src/document.h
+++ b/src/document.h
@@ -202,6 +202,9 @@ typedef struct RSAddDocumentCtx {
   // Old document data. Contains sortables
   RSDocumentMetadata *oldMd;
 
+  // New flags to assign to the document
+  RSDocumentFlags docFlags;
+
   // Scratch space used by per-type field preprocessors (see the source)
   union FieldData *fdatas;
   QueryError status;     // Error message is placed here if there is an error during processing

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -920,7 +920,6 @@ def testGeoDeletion(env):
             'g2', "-0.1757,51.5156",
             't1', "hello")
     
-    print env.cmd('keys', '*')
     # keys are: "geo:idx/g1" and "geo:idx/g2"
     env.assertEqual(2, env.cmd('zcard', 'geo:idx/g1'))
     env.assertEqual(2, env.cmd('zcard', 'geo:idx/g2'))
@@ -936,8 +935,6 @@ def testGeoDeletion(env):
             't1', 'just text here')
     env.assertEqual(0, env.cmd('zcard', 'geo:idx/g1'))
     env.assertEqual(0, env.cmd('zcard', 'geo:idx/g2'))
-
-
 
 def testAddHash(env):
     if env.is_cluster():

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -43,7 +43,11 @@ typedef enum {
   Document_Deleted = 0x01,
   Document_HasPayload = 0x02,
   Document_HasSortVector = 0x04,
-  Document_HasOffsetVector = 0x08
+  Document_HasOffsetVector = 0x08,
+
+  // Whether this document has any kind of 'on-demand'
+  // deletable field; this means any kind of numeric or geo
+  Document_HasOnDemandDeletable = 0x10
 } RSDocumentFlags;
 
 /* RSDocumentMetadata describes metadata stored about a document in the index (not the document


### PR DESCRIPTION
Ensures that geo fields are replaced the moment the document ID is
popped. This uses a flag to ensure that we don't scan for geo fields
when the document does not have them, so that performance is not
impacted otherwise.